### PR TITLE
SOF-7992: docs agent implementation and platform-actions plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ scripts/rag/chunks.jsonl
 # Agents workdir
 tmp
 .local-mkdocs*.yml
+
+# Local clone of the documentation-agent service repo (see plans/)
+reference/

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,10 +4,35 @@ Internal planning documents for work on this repository. These are **not part of
 the published documentation site** — the MkDocs builds only read `lang/en/docs/`,
 so nothing here appears on docs.mat3ra.com.
 
-| Document | Scope |
-| --- | --- |
-| [`docs-agent-rag.md`](docs-agent-rag.md) | The documentation agent: retrieval-augmented generation over this repository's content. Strategy, corpus analysis, evaluation approach. |
-| [`docs-agent-web-app.md`](docs-agent-web-app.md) | Delivering that agent as a browser-based chat: architecture, hosting, repository layout, deployment. |
+| Document | Scope | Status |
+| --- | --- | --- |
+| [`docs-agent-rag.md`](docs-agent-rag.md) | The documentation agent: retrieval-augmented generation over this repository's content. Strategy, corpus analysis, evaluation approach. | Active — Phase 0 of its content is built |
+| [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md) | Delivering that agent as a browser-based chat: architecture, hosting, repository layout, deployment. | Active — guides Phase 2 |
+| [`docs-agent-implementation.md`](docs-agent-implementation.md) | Execution plan tying the others together: phases, milestones, file-level work items, acceptance criteria, decision register. | Active — the progression tracker (§3) |
+| [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) | Letting the agent execute actions in the user's platform session: test-framework step reuse (Cypress/TeDe), in-page execution, safety model. | Proposed — needs sign-off + security review |
 
-The working implementation described by these plans lives in
-[`scripts/rag/`](../scripts/rag/).
+## Lifecycle
+
+Documents and work progress separately:
+
+- **Documents** carry a status — `Draft` (structure still moving), `Active`
+  (agreed direction, guiding work), `Proposed` (needs sign-off before build),
+  `Superseded` (kept for history) — and never move between folders, so
+  cross-links stay stable and Git records the history.
+- **Work** progresses by phase and milestone in the
+  [implementation plan](docs-agent-implementation.md) §3 — the single
+  tracker. A completed phase or milestone gets its State cell updated with
+  the date and pull request.
+- **Reviews are gates, not a folder:** open sign-offs live in the decision
+  register (D2, D3, D7, D8), and Phase 5 additionally requires a security
+  review before build.
+
+The documents share one phase numbering (Phases 0–5), defined in the
+[implementation plan](docs-agent-implementation.md) §3, and one vocabulary:
+**the platform** is platform.mat3ra.com, whose repository is `web-app`;
+**web delivery** is the browser chat for the documentation site.
+
+The working implementation lives in the
+[`documentation-agent`](https://github.com/mat3ra/documentation-agent)
+repository (decision D6). The superseded Phase-0 prototype is still in
+[`scripts/rag/`](../scripts/rag/) until that work is pushed.

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -1,0 +1,388 @@
+# Documentation Agent — Implementation Plan
+
+Execution plan for shipping the documentation assistant on docs.mat3ra.com.
+The companion documents hold the reasoning; this one holds the work: milestones,
+file-level work items, acceptance criteria, and the decisions still open.
+
+- **Status:** Active, living document — §3 is the initiative's progression
+  tracker. Nothing beyond Phase 0 (the prototypes) is built.
+- **Last updated:** 2026-07-31
+- **Companion plans:** [`docs-agent-rag.md`](docs-agent-rag.md) (retrieval and
+  evaluation strategy), [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md)
+  (architecture and hosting rationale)
+
+---
+
+## 1. Scope and definition of done
+
+Shipped means: an "Ask AI" launcher on every page of all four documentation
+sites opens a chat that streams grounded, cited answers from a production
+service, with abuse limits, spend controls, and an evaluation gate in CI.
+
+Out of scope for v1: hybrid/vector retrieval beyond an eval-gated upgrade
+(M7), the in-platform "Ask AI" surface (specified in M8, scheduled
+post-launch), and platform-action tools (specified in
+[`docs-agent-platform-actions.md`](docs-agent-platform-actions.md),
+sequenced after M8).
+
+## 2. Decision register
+
+Defaults follow the companion plans. Items marked **needs sign-off** block a
+later milestone but nothing before it.
+
+| # | Decision | Default | Status |
+| --- | --- | --- | --- |
+| D1 | Runtime | Cloud Run, same project as Vertex access ([web delivery plan §5](docs-agent-web-delivery.md), Option A) | Adopted |
+| D2 | Service code location | Private repository [`mat3ra/documentation-agent`](https://github.com/mat3ra/documentation-agent), pinned into the platform stack later if wanted | **Adopted** — repository created 2026-07-31 |
+| D3 | Google Cloud project | Dedicated project `mat3ra-documentation` with spend controls per M5.1 | **Adopted** — project created with budget and native spend cap (2026-07-31); Vertex AI API + Claude Model Garden enablement to confirm end-to-end |
+| D4 | Public endpoint | Default `*.run.app` URL for beta; a `mat3ra.com` subdomain before general availability | Beta default adopted |
+| D5 | Model | Provider abstraction over Vertex: **Gemini by default** (`gemini-3.6-flash`, `global`), Claude (`claude-opus-4-6`, `us-east5`) behind the same interface once Model Garden is enabled. Tier changes only through the evaluation harness | **Revised 2026-07-31** — Gemini needs no Model Garden step, so it unblocks work today; the abstraction keeps the choice reversible |
+| D6 | Core package location | The agent core (ingestion, retrieval, prompt, loop) lives in the **`documentation-agent` repository**; this repository provides the corpus only. Ingestion reads a documentation checkout via `--docs-root` | **Revised 2026-07-31** — supersedes the earlier "core stays in `scripts/rag/`" split; one repository owns all agent code, so there is no cross-repository package dependency to keep in step |
+| D7 | Logging and retention | Store question, tool trace, answer, and token counts for 30 days to seed the golden set; no IP addresses joined to content; disclosed in the widget footer | Needs sign-off before launch |
+| D8 | Launch quality bar | Thresholds set from the measured BM25 baseline (M2), not chosen aspirationally | Set during M2 |
+
+## 3. Phases and workstreams
+
+The initiative numbering, shared by all four plans (this table is the
+authority):
+
+| Phase | Name | Contents | State |
+| --- | --- | --- | --- |
+| 0 | Prototypes | BM25 demo in `scripts/rag/`; desktop automation experiment in the platform repository ([`web-app#2894`](https://github.com/mat3ra/web-app/pull/2894)) | **Done** |
+| 1 | Foundations | M1 core package, M2 evaluation harness | In progress — M1 done 2026-07-31, M2 next |
+| 2 | Docs launch | M3 service, M4 widget, M5 deployment, M6 hardening | Planned |
+| 3 | Retrieval quality | M7 upgrades, evaluation-gated | Planned, post-launch |
+| 4 | Platform embed | M8, stages M8.1–M8.3 | Planned, post-launch |
+| 5 | Platform actions | Stages A1–A4 in [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) | Proposed |
+
+Phases 3 and 4 are independent and can interleave; Phase 5 requires M8.2.
+
+This table (with the milestone table below) is the progression tracker: when
+a phase or milestone completes, its State cell gains the date and pull
+request. Documents keep their status in place — nothing moves to a
+"complete" folder.
+
+Within Phases 1–2, two tracks run interleaved — delivery (M1, M3–M6) and
+quality (M2) — reconciled as: **delivery does not wait for the full
+evaluation harness, but launch does.** Retrieval-metric evaluation (cheap,
+no model calls) lands before any retrieval change; the answer-quality gate
+must pass before M6.
+
+| Milestone | Phase | Track | Estimate |
+| --- | --- | --- | --- |
+| M1 Shared core package | 1 | Delivery | **Done 2026-07-31** |
+| M2 Evaluation harness + golden set | 1 | Quality | 2–3 days |
+| M3 Backend service | 2 | Delivery | 2–4 days |
+| M4 Documentation widget | 2 | Delivery | 3–5 days |
+| M5 Deployment + index pipeline | 2 | Delivery | 2–3 days |
+| M6 Launch hardening | 2 | Both | 1–2 days |
+| M7 Retrieval upgrades | 3 | Quality | 1–2 weeks |
+| M8 In-platform surface | 4 | Delivery | ~1 week, staged |
+
+Dependencies: M1 → M2 and M3; M3 → M4 (the widget develops against a local
+service); M5 can start alongside M4; M6 needs M2, M4, M5; M8 follows M6 and
+leans on M4's embeddable-module constraint; stages A1–A4 (Phase 5) follow
+M8.2. Elapsed time to a public beta (end of Phase 2): roughly two to three
+weeks of focused work.
+
+---
+
+## 4. Milestones
+
+### M1. Shared core package — **done 2026-07-31**
+
+The demo became the installable package the service will import, per
+[web delivery plan §3.1](docs-agent-web-delivery.md) ("refactor first"), in
+the `documentation-agent` repository (D6):
+
+```
+pyproject.toml              # mat3ra-docs-agent; [anthropic] and [dev] extras
+mat3ra_docs_agent/
+  config.py                 # environment-driven settings
+  ingest.py                 # chunker; --docs-root points at a docs checkout
+  retriever.py              # Retriever, tokenize, format_results
+  prompt.py                 # SYSTEM_PROMPT, SEARCH_TOOL
+  providers/                # base, gemini_vertex, anthropic_vertex
+  loop.py                   # run_turn, provider-agnostic
+  cli.py                    # docs-agent, docs-agent-ingest
+tests/                      # 42 tests, offline
+.github/workflows/tests.yml # pytest on 3.10 and 3.12
+```
+
+Beyond the original scope, the model backend was abstracted (D5): `Provider`
+exposes `add_user_message` / `add_tool_results` / `generate` over neutral
+types, each adapter holding the conversation in its own native format. The
+loop never sees a vendor dialect, which is what makes the Gemini-now,
+Claude-later switch a one-line change.
+
+Verified: 42 offline tests pass; ingestion reproduces the demo exactly (534
+pages → 2,554 chunks); a live query on Gemini returns the same two-method
+POSCAR answer with the same citations as the original demo.
+
+Two findings worth carrying forward:
+
+- **BM25 needs a realistic corpus.** Inverse document frequency is
+  meaningless over one document — scores go non-positive and the relevance
+  filter drops everything. Test fixtures use several pages; the M2 harness
+  must not evaluate against toy corpora.
+- **Gemini 3.x spends thinking tokens before emitting a tool call.** A small
+  output budget starves the call and produces an empty turn, so
+  `MAX_OUTPUT_TOKENS` is 8192.
+
+### M2. Evaluation harness and golden set (`documentation-agent` repository)
+
+The tuning loop from [RAG plan §5](docs-agent-rag.md). Layout:
+
+```
+eval/
+  golden.yaml          # question, expected page URL(s), key facts, answerable: bool
+  eval_retrieval.py    # recall@5, MRR — no model calls
+  eval_answers.py      # model-as-judge: faithfulness, citation validity, completeness
+  README.md            # how to run; the recorded BM25 baseline
+```
+
+Work items:
+
+1. Seed `golden.yaml` with ~30 entries (tutorial steps rephrased, pricing and
+   accounts FAQs, REST API usage, plus 5 unanswerable questions); grow toward
+   75–100 using logged real questions after launch (D7).
+2. `eval_retrieval.py` runs in seconds and prints per-question hits; record
+   the BM25 baseline in the eval README and set D8 thresholds from it.
+   Evaluate against the full index — never a toy corpus (M1 finding).
+3. `eval_answers.py` runs on demand (Vertex has no Batch API — standard
+   rates, so it is not a per-PR gate; retrieval metrics are). It is also
+   where the Gemini/Claude and model-tier comparison gets settled (D5).
+4. CI: retrieval evaluation runs on every pull request; a threshold
+   regression fails the check. It needs the index, so the workflow ingests
+   from a documentation checkout first.
+
+Acceptance: baseline numbers committed; a deliberate retrieval regression
+(e.g. top-k = 1) fails CI.
+
+### M3. Backend service (`documentation-agent` repository, D2)
+
+FastAPI wrapper around the core package, per [web delivery plan §3.1](docs-agent-web-delivery.md).
+
+Work items:
+
+1. Repository skeleton: `app/main.py`, `Dockerfile`, `README.md`, CI.
+2. `POST /chat` — request: message history (client-held, no server session
+   store); response: server-sent events — `text` deltas, `status` events
+   while a search runs ("Searching documentation…"), one final `sources`
+   event, then `done`.
+3. Streaming tool loop: add a `run_turn_streaming` generator to
+   `mat3ra_docs_agent.loop`, and a `stream()` method on `Provider`
+   implemented by both adapters, so the CLI and service share one loop.
+4. `GET /health` for the runtime probe.
+5. Guards, all request-tested: CORS allowlist (`https://docs.mat3ra.com`,
+   localhost origins for development), per-IP token-bucket rate limit
+   (in-process is acceptable at beta scale; note it resets on scale-to-zero),
+   caps on message count and body size per request, the existing 8-iteration
+   tool bound, and a per-conversation output-token ceiling.
+6. Structured request logs per D7: latency, tool calls, token usage, stop
+   reason — the observability list from [web delivery plan §6](docs-agent-web-delivery.md).
+
+Acceptance: `docker run` locally with ADC answers a question end-to-end with
+visible streaming; a scripted client verifies each guard (rejected origin,
+rate-limit 429, oversized body 413).
+
+### M4. Documentation widget (this repository)
+
+Embeddable chat on every page of the documentation sites, per
+[web delivery plan §3.2](docs-agent-web-delivery.md). Note the site count has
+grown past the four in `AGENTS.md`: CI now builds eight (adding Interface,
+Resources, Developers, Command Line, Standards), so verify the widget against
+the workflow's list rather than a remembered number.
+
+Work items:
+
+1. New assets, self-hosted (no CDN):
+
+   ```
+   lang/en/docs/extra/js/docs-agent.js        # launcher, panel, SSE client, renderer
+   lang/en/docs/extra/css/docs-agent.css
+   lang/en/docs/extra/js/vendor/              # marked + DOMPurify, pinned versions
+   ```
+
+   `docs-agent.js` is written as a framework-free embeddable module —
+   `DocsAgent.mount(element, {endpoint, tokenProvider})`, themed through CSS
+   custom properties, no MkDocs assumptions — so the platform surface (M8)
+   reuses it through a thin wrapper rather than a rewrite.
+
+2. Wire into `mkdocs-base.yml` (`extra_javascript`, `extra_css`). All four
+   site configs `INHERIT` the base, so this is a single edit — verify each
+   built site picks it up rather than editing four files.
+3. Behaviour: floating "Ask AI" launcher; panel with conversation held in
+   memory only; streamed Markdown rendered incrementally and sanitised
+   (DOMPurify) — model output is never injected as raw HTML; searching
+   indicator driven by `status` events; `sources` rendered as links; footer
+   with the D7 disclosure and an escalation link to support.
+4. Endpoint constant in `docs-agent.js` (D4 URL), with a `localStorage`
+   override for local development against `localhost`. If the endpoint is
+   unreachable or CORS-blocked (e.g. Netlify deploy previews), the launcher
+   hides — the widget must never break a documentation page.
+5. Keyboard and mobile pass: focus trap in the panel, Escape closes,
+   usable at phone widths.
+
+Acceptance: `./scripts/serve-all.sh` + local service answers with citations
+from any page of all four sites; `scripts/links/check-links.py` still passes;
+widget absent-but-silent when the service is down; the module also mounts in
+a bare HTML page with a single `mount()` call (the M8 embeddability check).
+
+### M5. Deployment and index pipeline
+
+Cloud Run runtime plus the two decoupled triggers from
+[web delivery plan §5.1](docs-agent-web-delivery.md).
+
+Work items:
+
+1. One-time cloud setup (D3): runtime service account with Vertex model
+   access and read access to the index bucket, nothing else; Workload
+   Identity Federation for both repositories' GitHub Actions — no key files
+   anywhere; budget on the project — **done 2026-07-31**: $100/month,
+   alerts at 50/80/100%, and the console's native spend cap (pauses
+   services on breach) configured. Costs are recorded with up to ~24 hours
+   of lag, so the cap is a backstop, not burst protection: Cloud Run
+   `--max-instances` times the per-request token caps (M3.5) still bounds
+   the worst-case burn rate, and Vertex per-model quotas can be lowered as
+   a second bound.
+2. Documentation trigger — small workflow in this repository: on push to
+   `main` touching `lang/en/docs/**`, fire a `repository_dispatch` carrying
+   the documentation SHA. It runs no ingestion; under D6 all agent logic
+   lives in the service repository.
+3. Service pipeline (service repository): on dispatch or own-repo push,
+   check out the documentation at that SHA, ingest, build the image
+   **baking in** the resulting index and the documentation SHA, deploy to a
+   staging revision, smoke-test (`/health` plus one golden question), then
+   promote. Rollback = redeploy the previous image, which carries its own
+   index.
+4. Runtime settings: scale-to-zero, small instance, concurrency tuned for
+   SSE; request timeout above the slowest multi-search answer observed.
+
+Acceptance: a trivial documentation edit on `main` propagates to a redeployed
+service without manual steps; rollback drill performed once; spend alert
+fires on a test threshold.
+
+### M6. Launch hardening
+
+Gate on all of: D7 signed off, D8 thresholds met on the golden set
+(including ≥ 90% correct behaviour on the unanswerable subset), M3 guard
+tests green, M5 rollback drill done.
+
+Work items:
+
+1. Decide and publish the privacy note (widget footer; optionally a short
+   documentation page — which adds a `mkdocs.yml` nav entry in the same
+   change, per repository convention).
+2. Re-run the full answer-quality evaluation against the production
+   endpoint, not just locally.
+3. Enable the widget on production by shipping the `mkdocs-base.yml` change
+   (until then, the widget branch stays unmerged — the docs deploy on push
+   to `main` via `s3-deploy.yml`, so merging is launching).
+4. Soft launch: announce internally, watch logs and spend for a week, then
+   announce publicly.
+
+### M7. Post-launch retrieval upgrades (quality track)
+
+In the order and for the reasons given in [RAG plan §4.3](docs-agent-rag.md),
+every step gated on the M2 harness: inline `--8<--` ESSE includes; contextual
+retrieval; embeddings + hybrid search (behind the same `Retriever.search`
+interface — no service change); `get_page` tool; reranking only if the
+numbers justify it; model-tier comparison for cost (D5).
+
+### M8. In-platform surface (platform.mat3ra.com)
+
+The second surface from [web delivery plan §2.2](docs-agent-web-delivery.md). The platform
+reuses the deployed service and the embeddable widget; retrieval, the agent
+loop, and model credentials never enter the platform application (rejected in
+[web delivery plan §2.1](docs-agent-web-delivery.md)).
+
+Reuse boundaries:
+
+- **Backend — reused as deployed.** The platform calls the same service and
+  `/chat` contract; there is no second deployment and nothing is ported to
+  Node. The browser talks to the service directly — the platform never
+  proxies the SSE stream (Meteor methods are RPC; the streaming mismatch was
+  §2.1's decisive row). Service change: the platform origin joins the CORS
+  allowlist.
+- **Frontend — reused as a module.** A thin React wrapper (a ref plus
+  `DocsAgent.mount()`, ~20 lines) hosts the M4 widget inside the platform
+  shell. The service serves its own built copy of the bundle
+  (`GET /widget.js`, copied from this repository during the M5 image build),
+  so the client the platform loads is version-locked to the API it calls; a
+  pinned vendored copy in the platform repository is the fallback if loading
+  a service-hosted script is unwanted there.
+- **Deliberately not reused:** no Vertex credentials in the platform, and no
+  platform-action tools in M8 itself — those are specified in
+  [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) behind
+  their own security review.
+
+Stages, each independently shippable:
+
+1. **M8.1 — anonymous embed (1–2 days, platform repository).** A
+   feature-flagged launcher mounts the widget against the production
+   endpoint. Platform users are treated like documentation visitors
+   (per-IP limits). Can ship any time after M6.
+2. **M8.2 — user identity via OIDC (1–2 days, mostly service-side).** The
+   platform already authenticates through OpenID Connect, so no token
+   endpoint is built: `tokenProvider` returns the signed-in user's ID
+   token, and the service validates it against the identity provider's
+   published keys (JWKS), checking audience and expiry — no shared secrets
+   to provision or rotate. Verified callers switch from per-IP to
+   per-account rate limits, with user context logged. Extends D7 —
+   retention for identified questions must be decided before M8.2 ships.
+   This identity gate is what the platform-actions capability
+   ([`docs-agent-platform-actions.md`](docs-agent-platform-actions.md))
+   builds on.
+3. **M8.3 — context hints (~1 day).** The wrapper passes the current platform
+   view (route or screen name) as a request field folded into the prompt, so
+   answers orient to where the user is. Client-supplied hints only — no
+   privileged data path.
+
+Acceptance: M8.1 answers with citations inside the platform behind the flag;
+under M8.2, two accounts on one address get independent rate budgets while
+anonymous callers stay IP-limited; the same widget keeps working unchanged
+on docs.mat3ra.com throughout.
+
+---
+
+## 5. Change inventory by location
+
+| Location | Changes |
+| --- | --- |
+| This repository (public) | Widget assets + `mkdocs-base.yml` wiring (M4); documentation-merge trigger (M5.2); privacy page if chosen (M6). The superseded Phase-0 demo still sits in `scripts/rag/` |
+| Service repository ([`documentation-agent`](https://github.com/mat3ra/documentation-agent), private) | Core package (M1, done); eval harness (M2); FastAPI app, streaming loop, Dockerfile, guards, deploy pipeline (M3, M5.3); serves the widget bundle, verifies platform tokens, per-account limits (M8) |
+| Platform repository (`web-app`, existing) | React wrapper + feature flag (M8.1); OIDC token wiring (M8.2); context hints (M8.3) |
+| Google Cloud (one-time) | Service account, WIF, index bucket, budget alert, Cloud Run service (M5.1) |
+
+## 6. Execution risks
+
+Strategy risks live in the companions ([RAG plan §8](docs-agent-rag.md),
+[web delivery plan §6](docs-agent-web-delivery.md)); these are risks to the execution:
+
+- **The public endpoint exists before launch** (M5 precedes M6). Keep the
+  staging service unlisted, CORS-locked, and rate-limited from its first
+  deploy; the widget merge, not the service deploy, is the launch event.
+- **Model deprecation on Vertex.** The pinned id will eventually retire, and
+  one default (`gemini-3.1-pro-preview`) is explicitly a preview. The M2
+  harness is the safety net — upgrade is a config change plus an evaluation
+  run, never a silent bump. Model availability is also region-specific
+  (Gemini 3.x is `global`-only today), so region and model move together.
+- **Golden-set staleness.** Documentation moves; expected-URL entries rot.
+  The retrieval evaluation doubles as the detector (a moved page drops
+  recall), and D7 logs supply replacement questions.
+- **Single-maintainer bandwidth.** Milestones are cut to merge
+  independently: each of M1–M5 leaves `main` shippable, and the plan
+  survives being picked up and put down between sessions.
+
+## 7. Immediate next actions
+
+1. **Commit and push M1** to `documentation-agent` (built and verified
+   locally 2026-07-31, not yet pushed).
+2. **M2 harness** in the same repository: the ~30-question seed, the
+   recorded BM25 baseline, D8 thresholds.
+3. **Retire the superseded demo** in `scripts/rag/` once M1 is pushed, so
+   there is one implementation rather than two.
+4. **Owner, when convenient:** enable the Claude models in Model Garden on
+   `mat3ra-documentation` to unblock the `anthropic` backend for the D5
+   comparison. Nothing is blocked on it — Gemini is the default and works.

--- a/plans/docs-agent-platform-actions.md
+++ b/plans/docs-agent-platform-actions.md
@@ -1,0 +1,194 @@
+# Documentation Agent — Platform Actions Plan
+
+Plan for letting the in-platform assistant execute actions for the user on
+platform.mat3ra.com, built on the test-automation framework rather than a
+separate action layer. Elaborates Phase 5 of the [RAG plan](docs-agent-rag.md)
+and extends milestone M8 of the
+[implementation plan](docs-agent-implementation.md).
+
+- **Status:** Proposed — needs sign-off and a security review before build.
+  Builds on the working experiment in
+  [mat3ra/web-app#2894](https://github.com/mat3ra/web-app/pull/2894)
+  (`experiment/mcp-server`).
+- **Initiative phase:** 5, staged A1–A4 (numbering per the
+  [implementation plan](docs-agent-implementation.md) §3). Throughout,
+  "the platform repository" means `web-app` — the code behind
+  platform.mat3ra.com.
+- **Last updated:** 2026-07-31
+- **Companion plans:** [`docs-agent-rag.md`](docs-agent-rag.md),
+  [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md),
+  [`docs-agent-implementation.md`](docs-agent-implementation.md)
+
+---
+
+## 1. Principle
+
+The agent may only do what the test suite can prove works, and only what the
+signed-in user could do by hand. Concretely: the action vocabulary **is** the
+Gherkin step library of the end-to-end tests, and execution happens **in the
+user's own browser session**, so the platform's existing authorization
+boundary is never widened.
+
+## 2. What already exists (PR 2894 inventory)
+
+The experiment branch in the platform repository contains a working desktop
+prototype of exactly this capability:
+
+| Piece | Contents | State |
+| --- | --- | --- |
+| `src/tests-cypress/` step definitions | Gherkin steps across ~30 domains (materials, jobs, workflows, billing, oidc, …) | In production CI use |
+| [`@mat3ra/tede`](https://github.com/mat3ra/tede) | The test framework: Feature → Step → Widget/TAO → Browser → Driver layering; the Browser layer exists precisely so the driver (Cypress, Webdriver, Playwright) is swappable | Published, reused across projects |
+| `src/mcp-server/` | `StepCatalog` (scans step definitions — 514 steps), `FeatureGenerator` (LLM → Gherkin with validation against the catalog), `runner` (executes `.feature` via Cypress CLI), LLM providers (Ollama, Gemini on Vertex) | Working |
+| `src/mat3ra-agent-desktop/` | Electron shell: chat panel, embedded browser, `PlaywrightStepExecutor` over CDP, widget ports (`LoginPage`, `MaterialDesignerWidget`, …), step log, intent classification (chat vs automation) | Working locally |
+
+Three things the experiment proves:
+
+1. Natural language → **validated** Gherkin works: generation is constrained
+   to catalog steps and rejected otherwise.
+2. Steps are driver-portable: the desktop ported Cypress widgets to
+   Playwright twice ("reuse cy steps with playwright"), confirming TeDe's
+   Browser abstraction does its job.
+3. Execution currently needs a privileged shell (Electron + CDP). Closing
+   that gap — execution from a plain web page — is what this plan adds.
+
+## 3. Execution model: in-page, in-session
+
+Where should steps execute? The options:
+
+| Option | Verdict |
+| --- | --- |
+| **In-page runner** in the user's session | **Chosen.** The user watches every step in their own tab; the user's session is the credential — nothing is delegated; nothing to install. Cypress is the existence proof: it already automates this application in-page with synthetic events, and the whole suite passes. |
+| Server-side browser (Playwright) acting as the user | Rejected: requires session delegation to a server (credential custody, a new attack surface), invisible to the user, heavy to operate. |
+| Browser extension / CDP | Rejected for the widget: install friction. CDP remains the desktop app's mechanism. |
+| REST-API tools (the original Phase-5 sketch in the RAG plan) | Deferred, not rejected: robust for bulk/headless operations, but requires API-token custody at the service, bypasses the UI the user is trying to learn, and is not exercised by the UI test suite. Revisit after the UI-step path ships. |
+
+The TeDe fit: implement a **DOM driver** for TeDe's Browser layer — the
+third driver after Cypress and the desktop's Playwright. Widgets, TAOs¹ and
+step definitions stay unchanged; the driver queries the live document and
+dispatches events (with the known native-setter technique for React
+controlled inputs, as Cypress does).
+
+¹ TAOs are excluded from the agent surface entirely: they exist to seed test
+data through privileged paths and have no business running in production.
+The agent gets UI widgets only.
+
+## 4. Architecture
+
+```
+platform.mat3ra.com (user signed in via OIDC)
+│
+│  Platform bundle ships: action runner = TeDe DOM driver + step executor
+│  + step catalog (versioned with the app), exposed as window.Mat3raAgentRunner
+│
+└─ Ask AI widget (M8, service-served)
+     │  POST /chat (SSE; OIDC ID token; client-held history;
+     │             reports the runner's catalog version)
+     ▼
+   docs-agent service ── tools: search_docs | propose_actions
+     ▼                              (validated against the reported catalog)
+   Claude on Vertex
+```
+
+Components:
+
+1. **Step-catalog artifact.** Built in the platform repository's CI from the step definitions
+   (the MCP server's `StepCatalog` scan, made a build step): step name,
+   parameters, domain, description, and a **mutation classification** (§5).
+   Shipped inside the platform bundle and published for the service.
+2. **Runner in the platform bundle, widget from the service.** The runner
+   (DOM driver + executor + catalog) is platform code, versioned and deployed
+   with the application — selectors, steps, and app can never skew. The chat
+   widget stays service-served (M8) and talks to the runner through a small
+   `window` API. The widget without the runner degrades to chat-only; the
+   service validates plans against the catalog version the client reports.
+3. **Planning in the service.** A `propose_actions` tool: the model drafts
+   steps, the service validates them against the catalog (porting
+   `FeatureGenerator`'s validation), invalid plans bounce back for repair.
+   This is where the two workstreams converge: `search_docs` tells the agent
+   *what* the procedure is (tutorials), the catalog tells it *how* to perform
+   it (steps) — one grounded loop does both.
+4. **Client-executed action protocol** on the existing stateless `/chat`:
+   when the model calls `propose_actions`, the SSE stream ends with an
+   `action_request` event carrying the validated plan. The widget renders the
+   plan with mutating steps highlighted; the user confirms once per plan;
+   the runner executes step-by-step with a live log and a stop button; the
+   widget appends the structured results (per-step status, error, DOM
+   context on failure) as the tool result in the client-held history and
+   POSTs `/chat` again. The model then continues — explains, repairs the
+   plan, or finishes. No server session state, exactly as in M3.
+
+## 5. Safety model (input to the security review)
+
+- **Vocabulary allowlist.** Only catalog steps can be planned (validated
+  server-side) or executed (validated again by the runner). There is no
+  free-form "evaluate JavaScript" or "click arbitrary selector" step.
+- **Per-step classification**, stored in the catalog, human-reviewed:
+  `read` (navigate, open, list, assert) runs unprompted once a plan is
+  confirmed; `mutate` (create, edit, submit) requires the plan-level
+  confirmation and is highlighted; `destructive-or-billing` (delete, purge,
+  purchase, share outside the account) is **blocked in v1** — the agent
+  explains the manual procedure with documentation citations instead.
+- **Session boundary.** Everything runs as the signed-in user in their own
+  tab; the service holds no platform credentials and cannot act when the
+  user is absent. OIDC identity (M8.2) gates the capability: anonymous
+  docs.mat3ra.com traffic never sees action tools.
+- **Visible and interruptible.** Live step log in the widget, a stop button
+  between steps, and per-step timeouts.
+- **Prompt injection.** DOM-derived tool results (element text, entity
+  names) re-enter the model and are treated as data; the vocabulary
+  constraint bounds what a poisoned string can cause. Injection scenarios —
+  e.g. a material named "ignore previous instructions…" — are an explicit
+  security-review test case.
+- **Audit.** Plan, confirmation, and per-step outcomes logged per account
+  (extends decision D7).
+- **Rollout.** Internal accounts → feature-flagged beta → general; the
+  capability flag in service configuration is the kill switch.
+
+## 6. The test framework as the quality loop
+
+This is the reason to build actions on the test suite rather than beside it:
+
+1. **Coverage by construction.** Every step the agent can execute is
+   exercised by the E2E suite in the platform repository's CI. A step that starts failing in
+   CI is pulled from the published catalog, and the agent degrades to
+   instructions-with-citations for that capability instead of failing
+   mid-action.
+2. **Golden action set.** The action analog of the M2 golden questions:
+   natural-language request → expected Gherkin plan → replay through the
+   existing Cypress runner against a seeded environment in CI. Catches both
+   planning regressions (prompt/model changes) and execution regressions
+   (app changes).
+3. **Cross-driver parity.** The same `.feature` must pass under the Cypress
+   driver (CI) and the DOM driver (the widget runner, driven by Playwright
+   in CI as the harness). Parity failures mean the DOM driver lies about a
+   capability.
+4. **New capabilities are test-driven.** Adding an agent skill = writing the
+   step definitions, widgets, and tests first; the catalog regenerates; the
+   agent can now plan with it. No agent-side code changes — the test suite
+   is the agent's skill tree.
+5. **The desktop app stays** as the step-development harness (interactive
+   Playwright execution, step log) and a power-user tool. Optional later
+   convergence: its planner calls the docs-agent service instead of local
+   Gemini/Ollama, keeping one planning implementation.
+
+## 7. Staging
+
+Sequenced after M8.2 (OIDC identity at the service). Each stage shippable
+alone.
+
+| Stage | Scope | Where | Estimate |
+| --- | --- | --- | --- |
+| A1 | Catalog build step with classification; TeDe DOM driver MVP (navigate, open explorer, click widget control, fill field, assert visible) with cross-driver parity tests | platform repo, `tede` | 3–5 days |
+| A2 | `propose_actions` + validation in the service; `action_request` protocol; capability flag, OIDC-gated | service repo, widget | 2–3 days |
+| A3 | Widget action mode: plan preview, confirmation, live step log, stop; `read` steps first, then `mutate` | widget, platform repo (runner exposure) | 3–5 days |
+| A4 | Golden action set in the platform repository's CI; audit logging; security review; internal beta | platform repo, service | 2–3 days + review |
+
+## 8. Open decisions
+
+1. **First domains.** Recommendation: materials and workflows, read-heavy
+   steps first — they map directly onto the most-read tutorials.
+2. **Classification ownership.** Who reviews and signs off the per-step
+   `read`/`mutate`/`blocked` labels; CI should fail on unclassified steps.
+3. **DOM driver home.** Recommendation: inside `@mat3ra/tede` next to the
+   existing drivers, versioned with the steps that depend on it.
+4. **Desktop convergence** on the service planner: worth doing, not urgent.

--- a/plans/docs-agent-rag.md
+++ b/plans/docs-agent-rag.md
@@ -3,10 +3,16 @@
 Plan for an assistant that answers user questions from the content of this
 repository (docs.mat3ra.com), grounded with Retrieval-Augmented Generation (RAG).
 
-- **Status:** Phase 1 in progress — a working demo is committed in
-  [`scripts/rag/`](../scripts/rag/).
-- **Last updated:** 2026-07-28
-- **Companion plan:** [`docs-agent-web-app.md`](docs-agent-web-app.md) (browser delivery)
+- **Status:** Active — the strategy reference for retrieval and evaluation.
+  Of its content, Phase 0 (prototypes) is complete — a working demo is
+  committed in [`scripts/rag/`](../scripts/rag/) and since rebuilt in the
+  [`documentation-agent`](https://github.com/mat3ra/documentation-agent)
+  repository (D6) — while evaluation (§5) and
+  retrieval upgrades (§4.3) are still ahead. Phase numbering and live
+  progression: [implementation plan](docs-agent-implementation.md) §3.
+- **Last updated:** 2026-07-31
+- **Companion plan:** [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md) (browser delivery)
+- **Implementation plan:** [`docs-agent-implementation.md`](docs-agent-implementation.md)
 
 ---
 
@@ -25,7 +31,7 @@ Claude on Vertex AI.
 | Contextual retrieval (chunk situating) | Not started |
 | `get_page` tool (fetch a whole page) | Not started |
 | Evaluation harness | Not started |
-| Any web interface | Not started — see the [web app plan](docs-agent-web-app.md) |
+| Any web interface | Not started — see the [web delivery plan](docs-agent-web-delivery.md) |
 
 Verified behaviour: asked how to import a material from a POSCAR file, the agent
 issued four searches (including section-filtered reformulations) and produced a
@@ -34,12 +40,17 @@ two-method answer citing `materials/actions/upload/` and
 
 ### What changed from the original proposal
 
-1. **Phase 0 was skipped.** The original plan proposed a "whole corpus in the
-   context window" baseline before building retrieval. Retrieval turned out to be
-   cheap enough to build directly, so the baseline was never needed. It remains
-   useful as a *quality ceiling* for evaluation (§5) and can still be run later.
-2. **The platform is Google Vertex AI, not the Claude API directly**, using
-   `claude-opus-4-6`. This constrains some of the original design — see §3.2.
+1. **The full-corpus baseline was skipped.** The original plan proposed a
+   "whole corpus in the context window" baseline before building retrieval.
+   Retrieval turned out to be cheap enough to build directly, so the baseline
+   was never needed. It remains useful as a *quality ceiling* for evaluation
+   (§5) and can still be run later.
+2. **The platform is Google Vertex AI, not the Claude API directly.** This
+   constrains some of the original design — see §3.2. The model is no longer
+   fixed: as of 2026-07-31 the agent runs behind a provider abstraction with
+   **Gemini as the default** (Claude on Vertex additionally requires Model
+   Garden enablement) and Claude selectable by configuration. Which one ships
+   is an evaluation question (§5), not a preference.
 3. **Retrieval is lexical (BM25), not vector-based.** This was a deliberate
    scope cut, not an oversight: it removes all index infrastructure from the
    demo while still exercising the full agent loop. Its limits are known and
@@ -69,8 +80,8 @@ User question
      │
      ▼
 ┌─────────────────────────────┐        ┌──────────────────────────┐
-│  Agent (scripts/rag/agent.py)│  tool  │  Retrieval               │
-│  claude-opus-4-6 on Vertex   │───────▶│  BM25 over doc chunks    │
+│  Agent (mat3ra_docs_agent)   │  tool  │  Retrieval               │
+│  Gemini or Claude on Vertex  │───────▶│  BM25 over doc chunks    │
 │  system prompt (cached)      │◀───────│  (→ hybrid, later)       │
 │  tool: search_docs           │ chunks └──────────────────────────┘
 └─────────────┬───────────────┘
@@ -88,8 +99,8 @@ Design decisions as implemented:
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Model | `claude-opus-4-6` (Vertex) | Strong tool use and grounding |
-| Region | `us-east5` | Confirmed working for this project; `global` also valid |
+| Model | Gemini by default, Claude behind the same interface | Both do grounded tool use; Gemini needs no Model Garden step, so it unblocks work |
+| Region | Per provider: Gemini `global`, Claude `us-east5` | Model availability is region-specific — Gemini 3.x is not served from `us-east5` |
 | Loop | Hand-written | The SDK `tool_runner` helper is not available on `AnthropicVertex` (verified against SDK 0.116) |
 | Caching | `cache_control` on the system prompt | Stable prefix, re-read on every turn |
 | Tool-loop bound | 8 iterations per user turn | Prevents a runaway loop from billing indefinitely |
@@ -189,7 +200,7 @@ The index is currently rebuilt by hand (`python ingest.py`). The generated
 
 For production: rebuild on merge to `main` in CI, and version the artifact with
 the documentation commit it was built from, so an answer can always be traced to
-a documentation snapshot. See the [web app plan](docs-agent-web-app.md) for how
+a documentation snapshot. See the [web delivery plan](docs-agent-web-delivery.md) for how
 that artifact reaches the deployed service.
 
 ---
@@ -214,8 +225,8 @@ prompt parameters. It is the highest-leverage unbuilt piece of this plan.
 4. **Tuning levers**, iterated against the golden set: chunk size, top-k, fusion
    weights, reranking, the contextual-retrieval prompt, system prompt wording,
    and model tier.
-5. **Regression gate:** run the evaluation in CI when `scripts/rag/` or the
-   system prompt changes.
+5. **Regression gate:** run the evaluation in CI on every change to the
+   agent repository — retrieval, prompt, or model configuration.
 
 Note the Vertex constraint from §3.2: no Batch API, so evaluation runs are
 billed at standard rates.
@@ -224,14 +235,21 @@ billed at standard rates.
 
 ## 6. Roadmap
 
+The phase numbering is shared by all four plans; the
+[implementation plan](docs-agent-implementation.md) §3 maps each phase to
+concrete milestones.
+
 | Phase | Scope | State |
 | --- | --- | --- |
-| 0 | Full-corpus-in-context baseline | Skipped — optional, as an evaluation ceiling |
-| 1 | Ingestion, BM25 retrieval, agentic loop, CLI | **Done** |
-| 2 | Golden set + evaluation harness | Next — everything below is tuned against it |
-| 3 | Contextual retrieval, embeddings, hybrid search, `get_page` | Planned (§4.3) |
-| 4 | Web delivery | See [`docs-agent-web-app.md`](docs-agent-web-app.md) |
-| 5 | Platform actions — tools generated from `rest-api/` docs, authenticated per user | Later; needs its own security review |
+| 0 | Prototypes: this repository's demo (ingestion, BM25 retrieval, agentic loop, CLI) and the platform repository's desktop automation experiment | **Done** |
+| 1 | Foundations: shared core package, golden set + evaluation harness | In progress — the package is done and now lives in the `documentation-agent` repository; the harness is next |
+| 2 | Docs launch: service, widget, deployment, hardening | Planned — see the [web delivery plan](docs-agent-web-delivery.md) |
+| 3 | Retrieval quality: contextual retrieval, embeddings, hybrid search, `get_page` (§4.3) | Planned, evaluation-gated |
+| 4 | Platform embed: the same widget inside platform.mat3ra.com | Planned |
+| 5 | Platform actions — the agent performs documented procedures in the user's session | Proposed in [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) (UI steps via the test framework; REST-API tools deferred); needs its own security review |
+
+The full-corpus-in-context baseline (the corpus fits a 1M-token window)
+remains available outside the numbering as an evaluation ceiling (§5).
 
 ---
 
@@ -259,7 +277,7 @@ current rates should be confirmed against Vertex pricing before committing.
 - **Stale answers after documentation edits** — CI re-indexing on merge (§4.4).
 - **Runaway tool loops** — bounded at 8 iterations per turn.
 - **Prompt injection and abuse** — relevant once the agent is exposed publicly;
-  covered in the [web app plan](docs-agent-web-app.md).
+  covered in the [web delivery plan](docs-agent-web-delivery.md).
 - **Query privacy** — user questions may contain proprietary research context. A
   logging and retention policy is required before any public deployment.
 - **Machine-translated pages** — `lang/ja/` is never indexed; multilingual

--- a/plans/docs-agent-web-delivery.md
+++ b/plans/docs-agent-web-delivery.md
@@ -1,11 +1,18 @@
-# Documentation Agent — Web App Plan
+# Documentation Agent — Web Delivery Plan
 
-Plan for turning the working command-line agent
-([`scripts/rag/agent.py`](../scripts/rag/agent.py)) into a browser-based chat.
+Plan for turning the working command-line agent (the `mat3ra_docs_agent`
+package in the
+[`documentation-agent`](https://github.com/mat3ra/documentation-agent)
+repository) into a browser-based chat.
+"Web delivery" here means shipping the documentation agent to browsers — not
+to be confused with the platform application, whose repository is named
+`web-app`.
 
-- **Status:** proposal — nothing built yet.
-- **Last updated:** 2026-07-28
+- **Status:** Active — the architecture reference for Phase 2 (docs launch);
+  nothing built yet.
+- **Last updated:** 2026-07-31
 - **Companion plan:** [`docs-agent-rag.md`](docs-agent-rag.md) (agent and retrieval strategy)
+- **Implementation plan:** [`docs-agent-implementation.md`](docs-agent-implementation.md)
 
 ---
 
@@ -49,10 +56,11 @@ retrieval plan's own schedule.
 
 ## 2. Where the service should live
 
-### 2.1. Not inside the platform web application
+### 2.1. Not inside the platform application
 
-The platform user interface is a large Meteor application. It is the wrong home
-for a public documentation assistant:
+The platform (platform.mat3ra.com) is a large Meteor application maintained
+in the `web-app` repository. It is the wrong home for a public documentation
+assistant:
 
 | | Standalone service | Inside the platform application |
 | --- | --- | --- |
@@ -129,17 +137,21 @@ launcher appears on every documentation page.
 The documentation repository is **public**. The service's operational
 configuration should not be. Split by what each part is coupled to:
 
+> **Revised 2026-07-31 (decision D6).** The split below was reconsidered: the
+> agent core now lives with the service rather than here. The reasoning about
+> what must stay private is unchanged; only the boundary moved.
+
 | Concern | Repository | Reason |
 | --- | --- | --- |
-| Corpus, ingestion, retrieval core, prompt | **This (public) repository**, in `scripts/rag/` | Coupled to the documentation; contains nothing sensitive; stays a runnable reference |
-| Service: HTTP layer, container, deployment manifests, access policy, rate limiting | **Separate private repository** | Coupled to infrastructure; matches the existing convention of one repository per service, aggregated into the platform stack as a submodule |
-| Built index | **Published artifact**, not committed | Generated content; versioned by the documentation commit it was built from |
+| Corpus (the Markdown itself) | **This (public) repository** | It is the documentation |
+| Ingestion, retrieval core, prompt, agent loop, HTTP service, container, deployment | **`documentation-agent` (private)** | One repository owns all agent code, so there is no cross-repository package version to keep in step; ingestion reads a documentation checkout at a pinned commit |
+| Built index | **Baked into the service image**, not committed | Generated content; versioned by the documentation commit it was built from |
 
-To avoid duplicating the retrieval core across two repositories, keep the
-dependency one-way: this repository publishes a small installable package that
-the private service depends on. That is preferable to the service vendoring the
-documentation repository, which would drag a large Git LFS history into a
-service image.
+The rejected alternative was a one-way package dependency (this repository
+publishing an installable core that the service imports). It works, but it
+splits one codebase across two release cadences for no gain now that the
+service is the only consumer. The service checks out the documentation at a
+specific SHA rather than vendoring it, so no Git LFS history enters the image.
 
 ---
 
@@ -213,14 +225,18 @@ for a demonstration; weaker as a foundation.
 
 ## 7. Roadmap
 
-| Step | Scope | Estimate |
+Milestone identifiers and phase numbering follow the
+[implementation plan](docs-agent-implementation.md) §3, which supersedes
+this table for sequencing.
+
+| Milestone (phase) | Scope | Estimate |
 | --- | --- | --- |
-| W0 | Extract `rag_core.py`; command-line wrapper imports it | 0.5 day |
-| W1 | FastAPI `/chat` with streaming and the tool loop; CORS; local run | 2–4 days |
-| W2 | Embeddable widget in the MkDocs theme; streamed Markdown and citations | 3–5 days |
-| W3 | Container, deployment pipeline, service-account auth, rate limiting, spend alerts | 2–3 days |
-| W4 | Hybrid retrieval behind the same interface; evaluation gate; latency tuning | 1–2 weeks |
-| Later | In-platform surface; authenticated action tools (separate security review) | As prioritised |
+| M1 (Phase 1) | Extract the shared core package; command-line wrapper imports it | 0.5–1 day |
+| M3 (Phase 2) | FastAPI `/chat` with streaming and the tool loop; CORS; local run | 2–4 days |
+| M4 (Phase 2) | Embeddable widget in the MkDocs theme; streamed Markdown and citations | 3–5 days |
+| M5 (Phase 2) | Container, deployment pipeline, service-account auth, rate limiting, spend alerts | 2–3 days |
+| M7 (Phase 3) | Hybrid retrieval behind the same interface; evaluation gate; latency tuning | 1–2 weeks |
+| Phases 4–5 | In-platform surface (M8); platform actions ([`docs-agent-platform-actions.md`](docs-agent-platform-actions.md), separate security review) | As prioritised |
 
 ## 8. Cost
 

--- a/scripts/rag/README.md
+++ b/scripts/rag/README.md
@@ -1,8 +1,17 @@
-# Docs RAG Agent — Minimal Demo
+# Docs RAG Agent — Minimal Demo (superseded)
+
+> **Superseded as of 2026-07-31.** This Phase-0 prototype has been rebuilt as
+> an installable package with a provider abstraction, tests, and CI in the
+> [`documentation-agent`](https://github.com/mat3ra/documentation-agent)
+> repository (decision D6 in
+> [`plans/docs-agent-implementation.md`](../../plans/docs-agent-implementation.md)).
+> It is kept here only until that work is pushed, then removed. New work goes
+> in the new repository.
+
 
 A grounded question-answering agent over the Mat3ra documentation. It retrieves
 relevant doc sections with BM25 and answers using **Claude Opus 4.6 on Google
-Vertex AI**, citing `docs.mat3ra.com` URLs. This is the Phase-1 minimal build
+Vertex AI**, citing `docs.mat3ra.com` URLs. This is the Phase-0 prototype
 from [`plans/docs-agent-rag.md`](../../plans/docs-agent-rag.md).
 
 ## What it does


### PR DESCRIPTION
Part of [SOF-7992](https://mat3ra.atlassian.net/browse/SOF-7992).

Stacked on `feat/agent-rag` (PR #389) because `plans/` only exists on that branch — this keeps the diff limited to the new work.

## What this adds

| Document | Scope |
| --- | --- |
| `plans/docs-agent-implementation.md` | Execution plan: shared phase numbering (0–5), milestones M1–M8 with acceptance criteria, decision register D1–D8, change inventory by repository |
| `plans/docs-agent-platform-actions.md` | Phase 5: the agent executing actions in the user's platform session |

## Naming consolidation

"The platform" is platform.mat3ra.com, whose repository is `web-app` — one vocabulary across all four documents. `docs-agent-web-app.md` is renamed to `docs-agent-web-delivery.md`: it describes browser delivery of the *documentation* agent and read as though it were about the platform repository.

Phase numbering is now shared by every plan and defined once in the implementation plan §3, so "Phase 2" means the same thing everywhere. Within-milestone steps are "stages" (M8.1–M8.3, A1–A4) to keep the word "phase" unambiguous.

## Platform actions, in brief

The agent's action vocabulary is the existing Cypress/Gherkin step catalog, building on the working prototype in [web-app#2894](https://github.com/mat3ra/web-app/pull/2894). Two consequences: the agent can only do what the E2E suite proves works, and adding a capability means writing the tests first. Steps execute in-page in the user's own session (no credential delegation), gated on OIDC identity, with destructive and billing steps blocked in v1.

## Decisions recorded since the plans were written

- **D6 revised** — the agent core lives in the new private [`documentation-agent`](https://github.com/mat3ra/documentation-agent) repository, not `scripts/rag/`. One repository owns all agent code; ingestion reads a documentation checkout at a pinned commit. `scripts/rag/` is marked superseded.
- **D5 revised** — the model backend is a provider abstraction: Gemini by default (no Model Garden step needed), Claude selectable behind the same interface.
- **D2/D3 adopted** — service repository created; GCP project `mat3ra-documentation` with a $100/month budget and spend cap.

## Notes

These are internal planning documents. The MkDocs builds only read `lang/en/docs/`, so nothing here reaches docs.mat3ra.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SOF-7992]: https://mat3ra.atlassian.net/browse/SOF-7992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ