### PR TITLE
SOF-7992: docs agent plans and the Ask AI widget

### DIFF
--- a/.github/workflows/docs-agent-index.yml
+++ b/.github/workflows/docs-agent-index.yml
@@ -1,0 +1,39 @@
+name: Refresh the documentation agent index
+
+# The agent answers from a snapshot of this repository's content, baked into
+# its container image. When the content changes, the snapshot is stale until
+# the service is rebuilt.
+#
+# This workflow does no ingestion of its own: all agent logic lives in the
+# documentation-agent repository, which checks this repository out at the
+# commit below and builds its own index. The two pipelines stay decoupled —
+# this one only says "the documentation moved, here is where".
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "lang/en/docs/**"
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Tell the agent repository to rebuild
+        # A token with `repo` scope on mat3ra/documentation-agent. The default
+        # GITHUB_TOKEN cannot dispatch across repositories.
+        env:
+          TOKEN: ${{ secrets.DOCS_AGENT_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "DOCS_AGENT_DISPATCH_TOKEN is not set; skipping the rebuild trigger." >&2
+            exit 0
+          fi
+          curl -fsS -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/mat3ra/documentation-agent/dispatches \
+            -d "{\"event_type\":\"documentation-updated\",\"client_payload\":{\"sha\":\"${GITHUB_SHA}\"}}"
+          echo "Requested a rebuild from documentation@${GITHUB_SHA}"

--- a/.github/workflows/widget-tests.yml
+++ b/.github/workflows/widget-tests.yml
@@ -1,0 +1,56 @@
+name: Ask AI widget tests
+
+# The widget ships to every documentation page, so a regression in it is a
+# regression on the whole site. These tests need no cloud access and no model
+# calls: the agent service is faked at the network boundary.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "extra/js/docs-agent.js"
+      - "extra/css/docs-agent.css"
+      - "tests/widget/**"
+      - ".github/workflows/widget-tests.yml"
+  pull_request:
+    paths:
+      - "extra/js/docs-agent.js"
+      - "extra/css/docs-agent.css"
+      - "tests/widget/**"
+      - ".github/workflows/widget-tests.yml"
+
+jobs:
+  playwright:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: tests/widget
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Install the browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run the tests
+        run: npx playwright test
+
+      - name: Upload the report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/widget/playwright-report
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ tmp
 
 # Local clone of the documentation-agent service repo (see plans/)
 reference/
+
+# Widget browser tests
+tests/widget/node_modules/
+tests/widget/test-results/
+tests/widget/playwright-report/

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ scripts/rag/chunks.jsonl
 # Agents workdir
 tmp
 .local-mkdocs*.yml
+
+# Local clone of the documentation-agent service repo (see plans/)
+reference/

--- a/extra/css/docs-agent.css
+++ b/extra/css/docs-agent.css
@@ -185,3 +185,41 @@
         width: auto;
     }
 }
+
+/* The Mat3ra mark next to the "Ask AI" label, in both the launcher and the
+ * panel header. Drawn in currentColor, so it inherits whatever it sits on. */
+.docs-agent-mark {
+    display: inline-flex;
+    align-items: center;
+    margin-right: 0.4rem;
+    vertical-align: -0.1em;
+}
+
+.docs-agent-launcher .docs-agent-mark svg {
+    width: 0.85rem;
+    height: 0.85rem;
+}
+
+.docs-agent-panel > header h2 {
+    display: flex;
+    align-items: center;
+}
+
+/* Product terms the answer emphasised, linked to the page that defines them.
+ * Kept looking like emphasis rather than a link so the answer still reads as
+ * prose, with the underline appearing on hover. */
+.docs-agent-term {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px dotted currentColor;
+}
+
+.docs-agent-term:hover,
+.docs-agent-term:focus {
+    text-decoration: underline;
+}
+
+/* Source URLs are long; let them wrap rather than widen the panel. */
+.docs-agent-message a {
+    word-break: break-word;
+}

--- a/extra/css/docs-agent.css
+++ b/extra/css/docs-agent.css
@@ -205,21 +205,19 @@
     align-items: center;
 }
 
-/* Product terms the answer emphasised, linked to the page that defines them.
- * Kept looking like emphasis rather than a link so the answer still reads as
- * prose, with the underline appearing on hover. */
+/* Anything clickable reads as a link: the documentation's own link colour where
+ * the theme defines one, and a conventional blue anywhere else the widget is
+ * embedded. Source URLs are long, so they wrap rather than widen the panel. */
+.docs-agent-message a,
 .docs-agent-term {
-    color: inherit;
+    color: var(--md-typeset-a-color, #1a73e8);
     text-decoration: none;
-    border-bottom: 1px dotted currentColor;
+    word-break: break-word;
 }
 
+.docs-agent-message a:hover,
+.docs-agent-message a:focus,
 .docs-agent-term:hover,
 .docs-agent-term:focus {
     text-decoration: underline;
-}
-
-/* Source URLs are long; let them wrap rather than widen the panel. */
-.docs-agent-message a {
-    word-break: break-word;
 }

--- a/extra/css/docs-agent.css
+++ b/extra/css/docs-agent.css
@@ -1,0 +1,187 @@
+/* Ask AI widget.
+ *
+ * Scoped under .docs-agent so nothing here can reach the documentation page,
+ * and sized in relative units so the panel stays usable at phone widths.
+ */
+
+.docs-agent-launcher {
+    position: fixed;
+    right: 1.25rem;
+    bottom: 1.25rem;
+    z-index: 30;
+    padding: 0.65rem 1.15rem;
+    border: none;
+    border-radius: 2rem;
+    background: var(--md-primary-fg-color, #2094f3);
+    color: #fff;
+    font-size: 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+}
+
+.docs-agent-launcher:hover {
+    filter: brightness(1.08);
+}
+
+.docs-agent-panel {
+    position: fixed;
+    right: 1.25rem;
+    bottom: 5rem;
+    z-index: 31;
+    display: flex;
+    flex-direction: column;
+    width: min(26rem, calc(100vw - 2.5rem));
+    max-height: min(34rem, calc(100vh - 8rem));
+    border: 1px solid var(--md-default-fg-color--lightest, #e0e0e0);
+    border-radius: 0.5rem;
+    background: var(--md-default-bg-color, #fff);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+    overflow: hidden;
+}
+
+.docs-agent-panel[hidden] {
+    display: none;
+}
+
+.docs-agent-panel > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.6rem 0.9rem;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest, #e0e0e0);
+}
+
+.docs-agent-panel > header h2 {
+    margin: 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+}
+
+.docs-agent-close {
+    border: none;
+    background: none;
+    font-size: 1.2rem;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--md-default-fg-color--light, #666);
+}
+
+.docs-agent-log {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.75rem 0.9rem;
+    font-size: 0.75rem;
+    line-height: 1.6;
+}
+
+.docs-agent-message {
+    margin-bottom: 0.9rem;
+}
+
+.docs-agent-message p {
+    margin: 0 0 0.5rem;
+}
+
+.docs-agent-message ul,
+.docs-agent-message ol {
+    margin: 0 0 0.5rem;
+    padding-left: 1.15rem;
+}
+
+.docs-agent-message pre {
+    margin: 0 0 0.5rem;
+    padding: 0.5rem 0.6rem;
+    border-radius: 0.25rem;
+    background: var(--md-code-bg-color, #f5f5f5);
+    /* Long commands scroll inside the block rather than widening the panel. */
+    overflow-x: auto;
+}
+
+.docs-agent-message code {
+    font-size: 0.9em;
+}
+
+.docs-agent-user {
+    padding: 0.4rem 0.6rem;
+    border-radius: 0.35rem;
+    background: var(--md-code-bg-color, #f5f5f5);
+    font-weight: 600;
+}
+
+.docs-agent-status {
+    color: var(--md-default-fg-color--light, #666);
+    font-style: italic;
+}
+
+.docs-agent-sources {
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid var(--md-default-fg-color--lightest, #e0e0e0);
+}
+
+.docs-agent-sources p {
+    margin: 0 0 0.25rem;
+    font-weight: 600;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--md-default-fg-color--light, #666);
+}
+
+.docs-agent-sources ul {
+    margin: 0;
+    padding-left: 1.15rem;
+    word-break: break-word;
+}
+
+.docs-agent-form {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0.6rem 0.9rem;
+    border-top: 1px solid var(--md-default-fg-color--lightest, #e0e0e0);
+}
+
+.docs-agent-form input {
+    flex: 1;
+    min-width: 0;
+    padding: 0.4rem 0.55rem;
+    border: 1px solid var(--md-default-fg-color--lighter, #ccc);
+    border-radius: 0.25rem;
+    background: var(--md-default-bg-color, #fff);
+    color: inherit;
+    font-size: 0.75rem;
+}
+
+.docs-agent-form button {
+    padding: 0.4rem 0.8rem;
+    border: none;
+    border-radius: 0.25rem;
+    background: var(--md-primary-fg-color, #2094f3);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.docs-agent-form button:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
+.docs-agent-footer {
+    margin: 0;
+    padding: 0 0.9rem 0.6rem;
+    font-size: 0.62rem;
+    line-height: 1.4;
+    color: var(--md-default-fg-color--light, #666);
+}
+
+@media screen and (max-width: 30rem) {
+    .docs-agent-panel {
+        right: 0.75rem;
+        left: 0.75rem;
+        bottom: 4.5rem;
+        width: auto;
+    }
+}

--- a/extra/css/docs-agent.css
+++ b/extra/css/docs-agent.css
@@ -221,3 +221,24 @@
 .docs-agent-term:focus {
     text-decoration: underline;
 }
+
+/* Header controls: ending a conversation and closing the panel. */
+.docs-agent-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.docs-agent-clear {
+    border: none;
+    background: none;
+    padding: 0;
+    font-size: 0.68rem;
+    cursor: pointer;
+    color: var(--md-default-fg-color--light, #666);
+}
+
+.docs-agent-clear:hover,
+.docs-agent-clear:focus {
+    text-decoration: underline;
+}

--- a/extra/js/docs-agent.js
+++ b/extra/js/docs-agent.js
@@ -18,7 +18,9 @@
 (function (global) {
     "use strict";
 
-    var DEFAULT_ENDPOINT = "https://docs-agent.mat3ra.com";
+    // Beta runs on the default Cloud Run hostname; a mat3ra.com subdomain
+    // replaces this before general availability.
+    var DEFAULT_ENDPOINT = "https://docs-agent-mmrcocqy3a-uc.a.run.app";
     var ENDPOINT_OVERRIDE_KEY = "docsAgentEndpoint"; // localStorage, for local development
     var MAX_QUESTION_CHARS = 4000;
 

--- a/extra/js/docs-agent.js
+++ b/extra/js/docs-agent.js
@@ -26,9 +26,16 @@
 
     // ---------------------------------------------------------------- markdown
 
-    var INLINE_PATTERN = /(`[^`]+`)|(\*\*[^*]+\*\*)|(\[[^\]]+\]\([^)\s]+\))/;
+    // Bare URLs are matched too: the model lists its sources as plain URLs, and
+    // a source you cannot click is not much of a citation.
+    var INLINE_PATTERN =
+        /(`[^`]+`)|(\*\*[^*]+\*\*)|(\[[^\]]+\]\([^)\s]+\))|(https:\/\/[^\s)\],<>"']+)/;
 
-    /** Append inline Markdown (code, bold, links) to a parent node. */
+    // Product term -> documentation page, fetched from the service. Built from
+    // the index there, so it can only ever name a page that exists.
+    var glossary = {};
+
+    /** Append inline Markdown (code, bold, links, bare URLs) to a parent node. */
     function renderInline(parent, text) {
         while (text) {
             var match = INLINE_PATTERN.exec(text);
@@ -45,17 +52,44 @@
                 code.textContent = token.slice(1, -1);
                 parent.appendChild(code);
             } else if (token.charAt(0) === "*") {
-                var strong = document.createElement("strong");
-                strong.textContent = token.slice(2, -2);
-                parent.appendChild(strong);
-            } else {
+                parent.appendChild(renderEmphasis(token.slice(2, -2)));
+            } else if (token.charAt(0) === "[") {
                 var split = token.indexOf("](");
-                var label = token.slice(1, split);
-                var href = token.slice(split + 2, -1);
-                parent.appendChild(safeLink(href, label));
+                parent.appendChild(safeLink(token.slice(split + 2, -1), token.slice(1, split)));
+            } else {
+                // A bare URL. Trailing sentence punctuation is not part of it.
+                var url = token.replace(/[.,;:]+$/, "");
+                parent.appendChild(safeLink(url, url));
+                text = text.slice(match.index + url.length);
+                continue;
             }
             text = text.slice(match.index + token.length);
         }
+    }
+
+    /**
+     * Emphasised text, linked to the page that defines it when the glossary
+     * knows the term.
+     *
+     * Answers name platform features in bold — Materials Bank, Materials
+     * Designer — and those are exactly the things a reader wants to open. The
+     * mapping comes from the service's index rather than from the model, so a
+     * link here can never point at a page that does not exist.
+     */
+    function renderEmphasis(label) {
+        var href = glossary[label.trim().toLowerCase()];
+        if (!href) {
+            var strong = document.createElement("strong");
+            strong.textContent = label;
+            return strong;
+        }
+        var link = safeLink(href, label);
+        if (link.tagName !== "A") return link;
+        link.className = "docs-agent-term";
+        link.title = "Open the documentation for " + label;
+        var bold = document.createElement("strong");
+        bold.appendChild(link);
+        return bold;
     }
 
     /**
@@ -182,6 +216,29 @@
         return pump();
     }
 
+    // ---------------------------------------------------------------- branding
+
+    // The Mat3ra mark, inlined and drawn in currentColor so it works on the
+    // purple launcher and on the panel header without shipping two assets or
+    // depending on a path that only exists on the documentation site.
+    var LOGO =
+        '<svg class="docs-agent-logo" viewBox="0 0 512 512" width="14" height="14" aria-hidden="true" focusable="false">' +
+        '<circle cx="256" cy="256" r="80" fill="currentColor"/>' +
+        '<path fill="currentColor" d="M334 100.056C334 50.8718 373.847 11 423 11C472.153 11 512 50.8718 512 100.056C512 130.306 480.115 171.982 480.115 171.982C480.115 171.982 427.327 236.133 427.327 256.326C427.327 276.516 456.851 312.743 480.115 341.285C497.341 362.431 512 383.184 512 411.944C512 461.128 472.153 501 423 501C373.847 501 334 461.128 334 411.944C334 384.78 349.322 361.543 365.887 341.285C389.152 312.74 418.674 276.516 418.674 256.326C418.674 236.289 366.784 171.982 366.784 171.982C366.784 171.982 334 131.672 334 100.056Z"/>' +
+        '<path fill="currentColor" d="M0 100.056C0 50.8718 39.8467 11 89 11C138.153 11 178 50.8718 178 100.056C178 130.306 146.115 171.982 146.115 171.982C146.115 171.982 93.3276 236.133 93.3276 256.326C93.3276 276.516 122.851 312.743 146.115 341.285C163.341 362.431 178 383.184 178 411.944C178 461.128 138.153 501 89 501C39.8467 501 0 461.128 0 411.944C0 384.78 15.3226 361.543 31.8867 341.285C55.1519 312.74 84.6738 276.516 84.6738 256.326C84.6738 236.289 32.7845 171.982 32.7845 171.982C32.7845 171.982 0 131.672 0 100.056Z"/>' +
+        "</svg>";
+
+    /** A label preceded by the mark. Built as nodes; the SVG is our own markup. */
+    function brandedLabel(text) {
+        var fragment = document.createDocumentFragment();
+        var holder = document.createElement("span");
+        holder.className = "docs-agent-mark";
+        holder.innerHTML = LOGO; // trusted constant above, never model output
+        fragment.appendChild(holder);
+        fragment.appendChild(document.createTextNode(text));
+        return fragment;
+    }
+
     // ------------------------------------------------------------------ widget
 
     function DocsAgentWidget(root, options) {
@@ -203,7 +260,7 @@
 
         var header = document.createElement("header");
         var title = document.createElement("h2");
-        title.textContent = "Ask AI";
+        title.appendChild(brandedLabel("Ask AI"));
         var close = document.createElement("button");
         close.type = "button";
         close.className = "docs-agent-close";
@@ -242,7 +299,7 @@
         var launcher = document.createElement("button");
         launcher.type = "button";
         launcher.className = "docs-agent-launcher";
-        launcher.textContent = "Ask AI";
+        launcher.appendChild(brandedLabel("Ask AI"));
         launcher.setAttribute("aria-expanded", "false");
 
         root.appendChild(launcher);
@@ -253,6 +310,7 @@
         this.input = input;
         this.send = send;
         this.launcher = launcher;
+        this.loadGlossary();
 
         launcher.addEventListener("click", function () {
             self.toggle(panel.hidden);
@@ -273,6 +331,20 @@
         });
 
         this.greet();
+    };
+
+    /** Fetch the term-to-page map once. Answers render fine without it. */
+    DocsAgentWidget.prototype.loadGlossary = function () {
+        fetch(this.endpoint + "/glossary")
+            .then(function (response) {
+                return response.ok ? response.json() : null;
+            })
+            .then(function (data) {
+                if (data && data.terms) glossary = data.terms;
+            })
+            .catch(function () {
+                /* Terms simply stay unlinked. */
+            });
     };
 
     DocsAgentWidget.prototype.toggle = function (open) {

--- a/extra/js/docs-agent.js
+++ b/extra/js/docs-agent.js
@@ -1,0 +1,450 @@
+/**
+ * Ask AI — the documentation assistant widget.
+ *
+ * Written as a framework-free module so the platform application can mount the
+ * same code inside its own shell:
+ *
+ *     DocsAgent.mount(element, { endpoint, tokenProvider });
+ *
+ * On the documentation site it mounts itself into the page (see the bottom of
+ * this file). It never assumes MkDocs.
+ *
+ * Model output is rendered by building DOM nodes and setting textContent —
+ * `innerHTML` is never used for anything the model or the corpus produced. That
+ * makes injection structurally impossible rather than filtered, which is why
+ * this file carries a small Markdown renderer instead of pulling in a Markdown
+ * parser plus a sanitiser.
+ */
+(function (global) {
+    "use strict";
+
+    var DEFAULT_ENDPOINT = "https://docs-agent.mat3ra.com";
+    var ENDPOINT_OVERRIDE_KEY = "docsAgentEndpoint"; // localStorage, for local development
+    var MAX_QUESTION_CHARS = 4000;
+
+    // ---------------------------------------------------------------- markdown
+
+    var INLINE_PATTERN = /(`[^`]+`)|(\*\*[^*]+\*\*)|(\[[^\]]+\]\([^)\s]+\))/;
+
+    /** Append inline Markdown (code, bold, links) to a parent node. */
+    function renderInline(parent, text) {
+        while (text) {
+            var match = INLINE_PATTERN.exec(text);
+            if (!match) {
+                parent.appendChild(document.createTextNode(text));
+                return;
+            }
+            if (match.index > 0) {
+                parent.appendChild(document.createTextNode(text.slice(0, match.index)));
+            }
+            var token = match[0];
+            if (token.charAt(0) === "`") {
+                var code = document.createElement("code");
+                code.textContent = token.slice(1, -1);
+                parent.appendChild(code);
+            } else if (token.charAt(0) === "*") {
+                var strong = document.createElement("strong");
+                strong.textContent = token.slice(2, -2);
+                parent.appendChild(strong);
+            } else {
+                var split = token.indexOf("](");
+                var label = token.slice(1, split);
+                var href = token.slice(split + 2, -1);
+                parent.appendChild(safeLink(href, label));
+            }
+            text = text.slice(match.index + token.length);
+        }
+    }
+
+    /**
+     * A link the model asked for. Only https targets become anchors; anything
+     * else (javascript:, data:, a relative path) is rendered as plain text, so
+     * a poisoned URL in the corpus cannot become a clickable trap.
+     */
+    function safeLink(href, label) {
+        if (!/^https:\/\//i.test(href)) {
+            return document.createTextNode(label + " (" + href + ")");
+        }
+        var anchor = document.createElement("a");
+        anchor.href = href;
+        anchor.textContent = label;
+        anchor.target = "_blank";
+        anchor.rel = "noopener noreferrer";
+        return anchor;
+    }
+
+    /** Render the Markdown subset the agent produces into `target`. */
+    function renderMarkdown(target, markdown) {
+        target.textContent = "";
+        var lines = markdown.split("\n");
+        var index = 0;
+        var list = null;
+
+        function closeList() {
+            list = null;
+        }
+
+        while (index < lines.length) {
+            var line = lines[index];
+
+            if (/^```/.test(line)) {
+                closeList();
+                var buffer = [];
+                index += 1;
+                while (index < lines.length && !/^```/.test(lines[index])) {
+                    buffer.push(lines[index]);
+                    index += 1;
+                }
+                index += 1;
+                var pre = document.createElement("pre");
+                var codeBlock = document.createElement("code");
+                codeBlock.textContent = buffer.join("\n");
+                pre.appendChild(codeBlock);
+                target.appendChild(pre);
+                continue;
+            }
+
+            var heading = /^(#{1,6})\s+(.*)$/.exec(line);
+            if (heading) {
+                closeList();
+                var level = Math.min(heading[1].length + 2, 6); // never outrank the page's own h1/h2
+                var headingNode = document.createElement("h" + level);
+                renderInline(headingNode, heading[2]);
+                target.appendChild(headingNode);
+                index += 1;
+                continue;
+            }
+
+            var bullet = /^\s*[-*]\s+(.*)$/.exec(line);
+            var numbered = /^\s*\d+\.\s+(.*)$/.exec(line);
+            if (bullet || numbered) {
+                var wanted = bullet ? "UL" : "OL";
+                if (!list || list.tagName !== wanted) {
+                    list = document.createElement(bullet ? "ul" : "ol");
+                    target.appendChild(list);
+                }
+                var item = document.createElement("li");
+                renderInline(item, (bullet || numbered)[1]);
+                list.appendChild(item);
+                index += 1;
+                continue;
+            }
+
+            if (!line.trim()) {
+                closeList();
+                index += 1;
+                continue;
+            }
+
+            closeList();
+            var paragraph = document.createElement("p");
+            renderInline(paragraph, line);
+            target.appendChild(paragraph);
+            index += 1;
+        }
+    }
+
+    // --------------------------------------------------------------- streaming
+
+    /** Read an SSE body, calling onEvent(name, data) per event. */
+    function readEvents(response, onEvent) {
+        var reader = response.body.getReader();
+        var decoder = new TextDecoder();
+        var buffer = "";
+
+        function pump() {
+            return reader.read().then(function (result) {
+                if (result.done) return;
+                buffer += decoder.decode(result.value, { stream: true });
+                var blocks = buffer.split("\n\n");
+                buffer = blocks.pop();
+                blocks.forEach(function (block) {
+                    var name = "";
+                    var payload = "";
+                    block.split("\n").forEach(function (line) {
+                        if (line.indexOf("event: ") === 0) name = line.slice(7);
+                        else if (line.indexOf("data: ") === 0) payload += line.slice(6);
+                    });
+                    if (!name) return;
+                    var data = {};
+                    try {
+                        data = payload ? JSON.parse(payload) : {};
+                    } catch (error) {
+                        return;
+                    }
+                    onEvent(name, data);
+                });
+                return pump();
+            });
+        }
+        return pump();
+    }
+
+    // ------------------------------------------------------------------ widget
+
+    function DocsAgentWidget(root, options) {
+        this.endpoint = (options && options.endpoint) || resolveEndpoint();
+        this.tokenProvider = (options && options.tokenProvider) || null;
+        this.messages = []; // conversation, in memory only
+        this.busy = false;
+        this.build(root);
+    }
+
+    DocsAgentWidget.prototype.build = function (root) {
+        var self = this;
+
+        var panel = document.createElement("section");
+        panel.className = "docs-agent-panel";
+        panel.setAttribute("role", "dialog");
+        panel.setAttribute("aria-label", "Ask the documentation assistant");
+        panel.hidden = true;
+
+        var header = document.createElement("header");
+        var title = document.createElement("h2");
+        title.textContent = "Ask AI";
+        var close = document.createElement("button");
+        close.type = "button";
+        close.className = "docs-agent-close";
+        close.setAttribute("aria-label", "Close");
+        close.textContent = "×";
+        header.appendChild(title);
+        header.appendChild(close);
+
+        var log = document.createElement("div");
+        log.className = "docs-agent-log";
+        log.setAttribute("aria-live", "polite");
+
+        var form = document.createElement("form");
+        form.className = "docs-agent-form";
+        var input = document.createElement("input");
+        input.type = "text";
+        input.placeholder = "Ask about the Mat3ra platform…";
+        input.setAttribute("aria-label", "Your question");
+        input.maxLength = MAX_QUESTION_CHARS;
+        var send = document.createElement("button");
+        send.type = "submit";
+        send.textContent = "Ask";
+        form.appendChild(input);
+        form.appendChild(send);
+
+        var footer = document.createElement("p");
+        footer.className = "docs-agent-footer";
+        footer.textContent =
+            "Answers are generated from the documentation and can be wrong. Questions are logged to improve the assistant.";
+
+        panel.appendChild(header);
+        panel.appendChild(log);
+        panel.appendChild(form);
+        panel.appendChild(footer);
+
+        var launcher = document.createElement("button");
+        launcher.type = "button";
+        launcher.className = "docs-agent-launcher";
+        launcher.textContent = "Ask AI";
+        launcher.setAttribute("aria-expanded", "false");
+
+        root.appendChild(launcher);
+        root.appendChild(panel);
+
+        this.panel = panel;
+        this.log = log;
+        this.input = input;
+        this.send = send;
+        this.launcher = launcher;
+
+        launcher.addEventListener("click", function () {
+            self.toggle(panel.hidden);
+        });
+        close.addEventListener("click", function () {
+            self.toggle(false);
+        });
+        form.addEventListener("submit", function (event) {
+            event.preventDefault();
+            var question = input.value.trim();
+            if (question && !self.busy) {
+                input.value = "";
+                self.ask(question);
+            }
+        });
+        panel.addEventListener("keydown", function (event) {
+            if (event.key === "Escape") self.toggle(false);
+        });
+
+        this.greet();
+    };
+
+    DocsAgentWidget.prototype.toggle = function (open) {
+        this.panel.hidden = !open;
+        this.launcher.setAttribute("aria-expanded", String(open));
+        if (open) this.input.focus();
+        else this.launcher.focus();
+    };
+
+    DocsAgentWidget.prototype.greet = function () {
+        var intro = document.createElement("div");
+        intro.className = "docs-agent-message docs-agent-assistant";
+        renderMarkdown(
+            intro,
+            "Ask a question about the Mat3ra platform. Answers come from this documentation, with links to the pages used."
+        );
+        this.log.appendChild(intro);
+    };
+
+    DocsAgentWidget.prototype.bubble = function (role, text) {
+        var node = document.createElement("div");
+        node.className = "docs-agent-message docs-agent-" + role;
+        if (text) node.textContent = text;
+        this.log.appendChild(node);
+        this.scroll();
+        return node;
+    };
+
+    DocsAgentWidget.prototype.scroll = function () {
+        this.log.scrollTop = this.log.scrollHeight;
+    };
+
+    DocsAgentWidget.prototype.ask = function (question) {
+        var self = this;
+        this.busy = true;
+        this.send.disabled = true;
+        this.bubble("user", question);
+        this.messages.push({ role: "user", content: question });
+
+        var answerNode = this.bubble("assistant", "");
+        var statusNode = document.createElement("p");
+        statusNode.className = "docs-agent-status";
+        statusNode.textContent = "Searching the documentation…";
+        answerNode.appendChild(statusNode);
+
+        var answer = "";
+        var pending = null;
+
+        function draw() {
+            pending = null;
+            renderMarkdown(answerNode, answer);
+            self.scroll();
+        }
+
+        Promise.resolve(this.tokenProvider ? this.tokenProvider() : null)
+            .then(function (token) {
+                var headers = { "Content-Type": "application/json" };
+                if (token) headers.Authorization = "Bearer " + token;
+                return fetch(self.endpoint + "/chat", {
+                    method: "POST",
+                    headers: headers,
+                    body: JSON.stringify({ messages: self.messages }),
+                });
+            })
+            .then(function (response) {
+                if (!response.ok || !response.body) {
+                    throw new Error("http " + response.status);
+                }
+                return readEvents(response, function (name, data) {
+                    if (name === "status") {
+                        statusNode.textContent = data.query
+                            ? "Searching the documentation: " + data.query
+                            : "Searching the documentation…";
+                    } else if (name === "text") {
+                        if (statusNode.parentNode) statusNode.remove();
+                        answer += data.text || "";
+                        if (!pending) pending = requestAnimationFrame(draw);
+                    } else if (name === "sources") {
+                        if (pending) cancelAnimationFrame(pending);
+                        draw();
+                        self.renderSources(answerNode, data.urls || [], answer);
+                    } else if (name === "error") {
+                        if (statusNode.parentNode) statusNode.remove();
+                        answer += "\n\n" + (data.message || "Something went wrong.");
+                        draw();
+                    }
+                });
+            })
+            .catch(function () {
+                if (statusNode.parentNode) statusNode.remove();
+                answer +=
+                    "\n\nThe assistant is unavailable right now. The documentation search box above still works.";
+                draw();
+            })
+            .then(function () {
+                if (answer) self.messages.push({ role: "assistant", content: answer });
+                self.busy = false;
+                self.send.disabled = false;
+                self.input.focus();
+            });
+    };
+
+    /**
+     * Show the pages retrieval touched — but only when the answer has not
+     * already cited its own.
+     *
+     * These two lists are not the same thing: the answer cites the pages the
+     * model *used*, while this event carries everything retrieval *returned*,
+     * which routinely includes near-misses the model correctly ignored.
+     * Printing both duplicates the useful list and dresses the near-misses up
+     * as sources, so the answer's own citations win whenever it has them.
+     */
+    DocsAgentWidget.prototype.renderSources = function (parent, urls, answer) {
+        if (!urls.length || /(^|\n)\s*(#+\s*)?\**sources\**\s*:?/i.test(answer)) return;
+        var wrapper = document.createElement("div");
+        wrapper.className = "docs-agent-sources";
+        var label = document.createElement("p");
+        label.textContent = "Pages searched";
+        var list = document.createElement("ul");
+        urls.forEach(function (url) {
+            var item = document.createElement("li");
+            item.appendChild(safeLink(url, url.replace(/^https:\/\/docs\.mat3ra\.com\//, "")));
+            list.appendChild(item);
+        });
+        wrapper.appendChild(label);
+        wrapper.appendChild(list);
+        parent.appendChild(wrapper);
+        this.scroll();
+    };
+
+    // ------------------------------------------------------------------ mounting
+
+    function resolveEndpoint() {
+        try {
+            return global.localStorage.getItem(ENDPOINT_OVERRIDE_KEY) || DEFAULT_ENDPOINT;
+        } catch (error) {
+            return DEFAULT_ENDPOINT;
+        }
+    }
+
+    var DocsAgent = {
+        mount: function (element, options) {
+            return new DocsAgentWidget(element, options || {});
+        },
+    };
+
+    /**
+     * Auto-mount on the documentation site, but only once the service answers
+     * its health check. A documentation page must never show a launcher that
+     * leads nowhere, and must never break because the assistant is down.
+     */
+    function autoMount() {
+        var endpoint = resolveEndpoint();
+        fetch(endpoint + "/health", { method: "GET" })
+            .then(function (response) {
+                if (!response.ok) throw new Error("unhealthy");
+                var host = document.createElement("div");
+                host.className = "docs-agent";
+                document.body.appendChild(host);
+                DocsAgent.mount(host, { endpoint: endpoint });
+            })
+            .catch(function () {
+                /* Service unavailable: leave the page exactly as it was. */
+            });
+    }
+
+    global.DocsAgent = DocsAgent;
+    global.DocsAgent._internals = { renderMarkdown: renderMarkdown, safeLink: safeLink };
+
+    if (typeof document !== "undefined" && !global.DOCS_AGENT_NO_AUTOMOUNT) {
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", autoMount);
+        } else {
+            autoMount();
+        }
+    }
+})(typeof window !== "undefined" ? window : this);

--- a/extra/js/docs-agent.js
+++ b/extra/js/docs-agent.js
@@ -104,8 +104,11 @@
         var anchor = document.createElement("a");
         anchor.href = href;
         anchor.textContent = label;
-        anchor.target = "_blank";
-        anchor.rel = "noopener noreferrer";
+        // Navigate in place: a documentation link is the continuation of the
+        // answer, not a detour, and opening tabs behind the reader is a habit
+        // the documentation itself does not have. The conversation is held in
+        // memory, so leaving the page ends it — the browser's back button
+        // returns to the documentation, not to the exchange.
         return anchor;
     }
 

--- a/extra/js/docs-agent.js
+++ b/extra/js/docs-agent.js
@@ -21,6 +21,13 @@
     // Beta runs on the default Cloud Run hostname; a mat3ra.com subdomain
     // replaces this before general availability.
     var DEFAULT_ENDPOINT = "https://docs-agent-mmrcocqy3a-uc.a.run.app";
+    var SESSION_KEY = "docsAgentSession";
+    // Following a source link is a normal part of reading an answer, and the
+    // page reloads when it happens. The conversation therefore has to outlive
+    // the page, or every citation would end the exchange that produced it.
+    var SESSION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+    var SESSION_MAX_MESSAGES = 20; // matches the service's own conversation cap
+    var SESSION_MAX_CHARS = 40000;
     var ENDPOINT_OVERRIDE_KEY = "docsAgentEndpoint"; // localStorage, for local development
     var MAX_QUESTION_CHARS = 4000;
 
@@ -106,9 +113,8 @@
         anchor.textContent = label;
         // Navigate in place: a documentation link is the continuation of the
         // answer, not a detour, and opening tabs behind the reader is a habit
-        // the documentation itself does not have. The conversation is held in
-        // memory, so leaving the page ends it — the browser's back button
-        // returns to the documentation, not to the exchange.
+        // the documentation itself does not have. The conversation survives the
+        // navigation because it is stored — see the session functions below.
         return anchor;
     }
 
@@ -264,13 +270,22 @@
         var header = document.createElement("header");
         var title = document.createElement("h2");
         title.appendChild(brandedLabel("Ask AI"));
+        // A conversation that survives navigation also has to be endable.
+        var clear = document.createElement("button");
+        clear.type = "button";
+        clear.className = "docs-agent-clear";
+        clear.textContent = "New chat";
         var close = document.createElement("button");
         close.type = "button";
         close.className = "docs-agent-close";
         close.setAttribute("aria-label", "Close");
         close.textContent = "×";
+        var controls = document.createElement("div");
+        controls.className = "docs-agent-controls";
+        controls.appendChild(clear);
+        controls.appendChild(close);
         header.appendChild(title);
-        header.appendChild(close);
+        header.appendChild(controls);
 
         var log = document.createElement("div");
         log.className = "docs-agent-log";
@@ -292,7 +307,9 @@
         var footer = document.createElement("p");
         footer.className = "docs-agent-footer";
         footer.textContent =
-            "Answers are generated from the documentation and can be wrong. Questions are logged to improve the assistant.";
+            "Answers are generated from the documentation and can be wrong. Questions are " +
+            "logged to improve the assistant, and this conversation is kept in your browser " +
+            "until you start a new chat.";
 
         panel.appendChild(header);
         panel.appendChild(log);
@@ -313,7 +330,6 @@
         this.input = input;
         this.send = send;
         this.launcher = launcher;
-        this.loadGlossary();
 
         launcher.addEventListener("click", function () {
             self.toggle(panel.hidden);
@@ -332,13 +348,24 @@
         panel.addEventListener("keydown", function (event) {
             if (event.key === "Escape") self.toggle(false);
         });
+        clear.addEventListener("click", function () {
+            self.clearSession();
+            self.log.textContent = "";
+            self.greet();
+            self.saveSession();
+            self.input.focus();
+        });
 
-        this.greet();
+        // Redraw the stored conversation once the glossary is available, so
+        // restored answers get the same links a fresh one would.
+        this.loadGlossary().then(function () {
+            self.restoreSession();
+        });
     };
 
     /** Fetch the term-to-page map once. Answers render fine without it. */
     DocsAgentWidget.prototype.loadGlossary = function () {
-        fetch(this.endpoint + "/glossary")
+        return fetch(this.endpoint + "/glossary")
             .then(function (response) {
                 return response.ok ? response.json() : null;
             })
@@ -350,11 +377,92 @@
             });
     };
 
+    // ------------------------------------------------------------------ session
+
+    /**
+     * The conversation, kept in the browser so it survives navigation.
+     *
+     * Answers cite documentation pages and those links now open in place, so
+     * without this every citation would discard the exchange that produced it.
+     * Nothing is sent anywhere by storing it: this is the same text the page
+     * already displays, on the reader's own machine, and the panel offers a way
+     * to clear it.
+     */
+    DocsAgentWidget.prototype.saveSession = function () {
+        try {
+            var messages = this.messages.slice(-SESSION_MAX_MESSAGES);
+            while (
+                messages.length &&
+                messages.reduce(function (total, m) {
+                    return total + m.content.length;
+                }, 0) > SESSION_MAX_CHARS
+            ) {
+                messages.shift();
+            }
+            global.localStorage.setItem(
+                SESSION_KEY,
+                JSON.stringify({
+                    version: 1,
+                    updated: Date.now(),
+                    open: !this.panel.hidden,
+                    messages: messages,
+                })
+            );
+        } catch (error) {
+            /* Storage full or disabled: the widget still works for this page. */
+        }
+    };
+
+    DocsAgentWidget.prototype.readSession = function () {
+        try {
+            var stored = JSON.parse(global.localStorage.getItem(SESSION_KEY) || "null");
+            if (!stored || stored.version !== 1 || !Array.isArray(stored.messages)) return null;
+            if (Date.now() - (stored.updated || 0) > SESSION_MAX_AGE_MS) {
+                this.clearSession();
+                return null;
+            }
+            return stored;
+        } catch (error) {
+            return null;
+        }
+    };
+
+    DocsAgentWidget.prototype.clearSession = function () {
+        this.messages = [];
+        try {
+            global.localStorage.removeItem(SESSION_KEY);
+        } catch (error) {
+            /* Nothing to clear. */
+        }
+    };
+
+    /** Redraw a stored conversation and reopen the panel if it was open. */
+    DocsAgentWidget.prototype.restoreSession = function () {
+        var stored = this.readSession();
+        if (!stored || !stored.messages.length) {
+            this.greet();
+            return;
+        }
+        this.messages = stored.messages;
+        var self = this;
+        stored.messages.forEach(function (message) {
+            if (message.role === "user") {
+                self.bubble("user", message.content);
+            } else {
+                renderMarkdown(self.bubble("assistant", ""), message.content);
+            }
+        });
+        this.scroll();
+        if (stored.open) this.toggle(true);
+    };
+
     DocsAgentWidget.prototype.toggle = function (open) {
         this.panel.hidden = !open;
         this.launcher.setAttribute("aria-expanded", String(open));
         if (open) this.input.focus();
         else this.launcher.focus();
+        // Remember whether it was open, so following a link does not close it.
+        this.saveSession();
     };
 
     DocsAgentWidget.prototype.greet = function () {
@@ -386,6 +494,7 @@
         this.send.disabled = true;
         this.bubble("user", question);
         this.messages.push({ role: "user", content: question });
+        this.saveSession();
 
         var answerNode = this.bubble("assistant", "");
         var statusNode = document.createElement("p");
@@ -444,6 +553,7 @@
             })
             .then(function () {
                 if (answer) self.messages.push({ role: "assistant", content: answer });
+                self.saveSession();
                 self.busy = false;
                 self.send.disabled = false;
                 self.input.focus();

--- a/extra/js/docs-agent.js
+++ b/extra/js/docs-agent.js
@@ -42,6 +42,16 @@
     // the index there, so it can only ever name a page that exists.
     var glossary = {};
 
+    var CANONICAL_DOCS_ORIGIN = "https://docs.mat3ra.com";
+    // When the widget runs on a documentation build that is not production — a
+    // deploy preview, or a local server — citations should stay on the build
+    // being read. The corpus stores canonical production URLs, so following one
+    // otherwise leaves the preview entirely, which loses the conversation with
+    // it: storage is per-origin. Set only where the widget mounts itself onto a
+    // documentation site; the platform shell serves no documentation and must
+    // keep sending readers to the real thing.
+    var docsOrigin = "";
+
     /** Append inline Markdown (code, bold, links, bare URLs) to a parent node. */
     function renderInline(parent, text) {
         while (text) {
@@ -99,6 +109,13 @@
         return bold;
     }
 
+    /** Point a canonical documentation URL at the build currently being read. */
+    function localDocsUrl(href) {
+        if (!docsOrigin || docsOrigin === CANONICAL_DOCS_ORIGIN) return href;
+        if (href.indexOf(CANONICAL_DOCS_ORIGIN + "/") !== 0) return href;
+        return docsOrigin + href.slice(CANONICAL_DOCS_ORIGIN.length);
+    }
+
     /**
      * A link the model asked for. Only https targets become anchors; anything
      * else (javascript:, data:, a relative path) is rendered as plain text, so
@@ -109,7 +126,7 @@
             return document.createTextNode(label + " (" + href + ")");
         }
         var anchor = document.createElement("a");
-        anchor.href = href;
+        anchor.href = localDocsUrl(href);
         anchor.textContent = label;
         // Navigate in place: a documentation link is the continuation of the
         // answer, not a detour, and opening tabs behind the reader is a habit
@@ -253,6 +270,7 @@
     function DocsAgentWidget(root, options) {
         this.endpoint = (options && options.endpoint) || resolveEndpoint();
         this.tokenProvider = (options && options.tokenProvider) || null;
+        if (options && options.docsOrigin) docsOrigin = options.docsOrigin;
         this.messages = []; // conversation, in memory only
         this.busy = false;
         this.build(root);
@@ -617,7 +635,9 @@
                 var host = document.createElement("div");
                 host.className = "docs-agent";
                 document.body.appendChild(host);
-                DocsAgent.mount(host, { endpoint: endpoint });
+                // Self-mounting means this page *is* a documentation build, so
+                // citations should stay on it rather than jumping to production.
+                DocsAgent.mount(host, { endpoint: endpoint, docsOrigin: global.location.origin });
             })
             .catch(function () {
                 /* Service unavailable: leave the page exactly as it was. */

--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -9,6 +9,7 @@ extra_css:
     - extra/css/images.css
     - extra/css/super-fences.css
     - extra/css/properties.css
+    - extra/css/docs-agent.css
     - https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css
 
 extra_javascript:
@@ -18,6 +19,9 @@ extra_javascript:
     - extra/js/katex.js
     - extra/js/clickable-rows.js
     - extra/js/search-hint.js
+    # Self-mounting; hides itself when the agent service is unreachable, so a
+    # documentation page never shows a launcher that leads nowhere.
+    - extra/js/docs-agent.js
     - https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js
     - https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js
     - 'https://www.googletagmanager.com/gtag/js?id=UA-69270713-5'

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,10 +4,35 @@ Internal planning documents for work on this repository. These are **not part of
 the published documentation site** — the MkDocs builds only read `lang/en/docs/`,
 so nothing here appears on docs.mat3ra.com.
 
-| Document | Scope |
-| --- | --- |
-| [`docs-agent-rag.md`](docs-agent-rag.md) | The documentation agent: retrieval-augmented generation over this repository's content. Strategy, corpus analysis, evaluation approach. |
-| [`docs-agent-web-app.md`](docs-agent-web-app.md) | Delivering that agent as a browser-based chat: architecture, hosting, repository layout, deployment. |
+| Document | Scope | Status |
+| --- | --- | --- |
+| [`docs-agent-rag.md`](docs-agent-rag.md) | The documentation agent: retrieval-augmented generation over this repository's content. Strategy, corpus analysis, evaluation approach. | Active — Phase 0 of its content is built |
+| [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md) | Delivering that agent as a browser-based chat: architecture, hosting, repository layout, deployment. | Active — guides Phase 2 |
+| [`docs-agent-implementation.md`](docs-agent-implementation.md) | Execution plan tying the others together: phases, milestones, file-level work items, acceptance criteria, decision register. | Active — the progression tracker (§3) |
+| [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) | Letting the agent execute actions in the user's platform session: test-framework step reuse (Cypress/TeDe), in-page execution, safety model. | Proposed — needs sign-off + security review |
 
-The working implementation described by these plans lives in
-[`scripts/rag/`](../scripts/rag/).
+## Lifecycle
+
+Documents and work progress separately:
+
+- **Documents** carry a status — `Draft` (structure still moving), `Active`
+  (agreed direction, guiding work), `Proposed` (needs sign-off before build),
+  `Superseded` (kept for history) — and never move between folders, so
+  cross-links stay stable and Git records the history.
+- **Work** progresses by phase and milestone in the
+  [implementation plan](docs-agent-implementation.md) §3 — the single
+  tracker. A completed phase or milestone gets its State cell updated with
+  the date and pull request.
+- **Reviews are gates, not a folder:** open sign-offs live in the decision
+  register (D2, D3, D7, D8), and Phase 5 additionally requires a security
+  review before build.
+
+The documents share one phase numbering (Phases 0–5), defined in the
+[implementation plan](docs-agent-implementation.md) §3, and one vocabulary:
+**the platform** is platform.mat3ra.com, whose repository is `web-app`;
+**web delivery** is the browser chat for the documentation site.
+
+The working implementation lives in the
+[`documentation-agent`](https://github.com/mat3ra/documentation-agent)
+repository (decision D6). The superseded Phase-0 prototype is still in
+[`scripts/rag/`](../scripts/rag/) until that work is pushed.

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -75,7 +75,7 @@ must pass before M6.
 | M1 Shared core package | 1 | Delivery | **Done 2026-07-31** |
 | M2 Evaluation harness + golden set | 1 | Quality | **Done 2026-07-31** |
 | M3 Backend service | 2 | Delivery | **Done 2026-07-31** |
-| M4 Documentation widget | 2 | Delivery | **Done 2026-07-31** |
+| M4 Documentation widget | 2 | Delivery | **Done 2026-08-01** |
 | M5 Deployment + index pipeline | 2 | Delivery | **Done 2026-07-31** |
 | M6 Launch hardening | 2 | Both | 1–2 days |
 | M7 Retrieval upgrades | 3 | Quality | 1–2 weeks |
@@ -224,11 +224,31 @@ Acceptance: `docker run` locally with ADC answers a question end-to-end with
 visible streaming; a scripted client verifies each guard (rejected origin,
 rate-limit 429, oversized body 413).
 
-### M4. Documentation widget (this repository)
+### M4. Documentation widget — **done 2026-08-01**
 
-Embeddable chat on every page of the documentation sites, per
-[web delivery plan §3.2](docs-agent-web-delivery.md). Note the site count has
-grown past the four in `AGENTS.md`: CI now builds eight (adding Interface,
+Live on the deploy preview and covered by 17 Playwright tests
+(`tests/widget/`) that run in CI in under three seconds without cloud access
+or a model call — the widget is real, only the service is faked at the
+network boundary.
+
+Four things the first real use taught, each now a test:
+
+- **Citations must be clickable and same-tab.** The model lists sources as
+  bare URLs, which the renderer did not recognise, so every citation arrived
+  as dead text.
+- **Emphasised product terms should link**, from a glossary the service
+  derives from its own index — never from the model. Terms that more than one
+  page claims are dropped: a confident link to the wrong product's page is
+  worse than bold text.
+- **Citations must stay on the build being read.** The corpus stores
+  canonical production URLs, so following one from a preview left the preview
+  — and the conversation with it, storage being per-origin.
+- **The conversation has to outlive the page.** Once links open in place,
+  every citation ended the exchange that produced it. It is now stored,
+  bounded and expiring, with "New chat" to end it.
+
+The remaining scope note stands: the site count has grown past the four in
+`AGENTS.md` — CI now builds eight (adding Interface,
 Resources, Developers, Command Line, Standards), so verify the widget against
 the workflow's list rather than a remembered number.
 
@@ -467,6 +487,13 @@ remains, and most of what is left is judgement rather than code.
 4. **Two secrets to add:** `DOCS_AGENT_DISPATCH_TOKEN` in this repository, so
    a documentation merge triggers a rebuild; the pipeline skips with a
    message until then, rather than failing the build.
+5. **Upgrade the local Google Cloud SDK.** It is still 437.0.1 (June 2023),
+   and Google rejects that client's token refresh: a fresh `gcloud auth
+   login` works for about an hour and then every call fails with
+   `ACCESS_TOKEN_TYPE_UNSUPPORTED`. Re-authenticating treats the symptom
+   hourly; `brew upgrade` fixes it. Nothing deployed depends on it — Cloud
+   Run uses its own service account — but no deploy can be run from a laptop
+   in this state.
 5. **Retire the superseded demo** in `scripts/rag/` so there is one
    implementation rather than two.
 6. **Owner, when convenient:** enable the Claude models in Model Garden on

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -1,0 +1,388 @@
+# Documentation Agent — Implementation Plan
+
+Execution plan for shipping the documentation assistant on docs.mat3ra.com.
+The companion documents hold the reasoning; this one holds the work: milestones,
+file-level work items, acceptance criteria, and the decisions still open.
+
+- **Status:** Active, living document — §3 is the initiative's progression
+  tracker. Nothing beyond Phase 0 (the prototypes) is built.
+- **Last updated:** 2026-07-31
+- **Companion plans:** [`docs-agent-rag.md`](docs-agent-rag.md) (retrieval and
+  evaluation strategy), [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md)
+  (architecture and hosting rationale)
+
+---
+
+## 1. Scope and definition of done
+
+Shipped means: an "Ask AI" launcher on every page of all four documentation
+sites opens a chat that streams grounded, cited answers from a production
+service, with abuse limits, spend controls, and an evaluation gate in CI.
+
+Out of scope for v1: hybrid/vector retrieval beyond an eval-gated upgrade
+(M7), the in-platform "Ask AI" surface (specified in M8, scheduled
+post-launch), and platform-action tools (specified in
+[`docs-agent-platform-actions.md`](docs-agent-platform-actions.md),
+sequenced after M8).
+
+## 2. Decision register
+
+Defaults follow the companion plans. Items marked **needs sign-off** block a
+later milestone but nothing before it.
+
+| # | Decision | Default | Status |
+| --- | --- | --- | --- |
+| D1 | Runtime | Cloud Run, same project as Vertex access ([web delivery plan §5](docs-agent-web-delivery.md), Option A) | Adopted |
+| D2 | Service code location | Private repository [`mat3ra/documentation-agent`](https://github.com/mat3ra/documentation-agent), pinned into the platform stack later if wanted | **Adopted** — repository created 2026-07-31 |
+| D3 | Google Cloud project | Dedicated project `mat3ra-documentation` with spend controls per M5.1 | **Adopted** — project created with budget and native spend cap (2026-07-31); Vertex AI API + Claude Model Garden enablement to confirm end-to-end |
+| D4 | Public endpoint | Default `*.run.app` URL for beta; a `mat3ra.com` subdomain before general availability | Beta default adopted |
+| D5 | Model | Provider abstraction over Vertex: **Gemini by default** (`gemini-3.6-flash`, `global`), Claude (`claude-opus-4-6`, `us-east5`) behind the same interface once Model Garden is enabled. Tier changes only through the evaluation harness | **Revised 2026-07-31** — Gemini needs no Model Garden step, so it unblocks work today; the abstraction keeps the choice reversible |
+| D6 | Core package location | The agent core (ingestion, retrieval, prompt, loop) lives in the **`documentation-agent` repository**; this repository provides the corpus only. Ingestion reads a documentation checkout via `--docs-root` | **Revised 2026-07-31** — supersedes the earlier "core stays in `scripts/rag/`" split; one repository owns all agent code, so there is no cross-repository package dependency to keep in step |
+| D7 | Logging and retention | Store question, tool trace, answer, and token counts for 30 days to seed the golden set; no IP addresses joined to content; disclosed in the widget footer | Needs sign-off before launch |
+| D8 | Launch quality bar | Thresholds set from the measured BM25 baseline (M2), not chosen aspirationally | Set during M2 |
+
+## 3. Phases and workstreams
+
+The initiative numbering, shared by all four plans (this table is the
+authority):
+
+| Phase | Name | Contents | State |
+| --- | --- | --- | --- |
+| 0 | Prototypes | BM25 demo in `scripts/rag/`; desktop automation experiment in the platform repository ([`web-app#2894`](https://github.com/mat3ra/web-app/pull/2894)) | **Done** |
+| 1 | Foundations | M1 core package, M2 evaluation harness | In progress — M1 done 2026-07-31, M2 next |
+| 2 | Docs launch | M3 service, M4 widget, M5 deployment, M6 hardening | Planned |
+| 3 | Retrieval quality | M7 upgrades, evaluation-gated | Planned, post-launch |
+| 4 | Platform embed | M8, stages M8.1–M8.3 | Planned, post-launch |
+| 5 | Platform actions | Stages A1–A4 in [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) | Proposed |
+
+Phases 3 and 4 are independent and can interleave; Phase 5 requires M8.2.
+
+This table (with the milestone table below) is the progression tracker: when
+a phase or milestone completes, its State cell gains the date and pull
+request. Documents keep their status in place — nothing moves to a
+"complete" folder.
+
+Within Phases 1–2, two tracks run interleaved — delivery (M1, M3–M6) and
+quality (M2) — reconciled as: **delivery does not wait for the full
+evaluation harness, but launch does.** Retrieval-metric evaluation (cheap,
+no model calls) lands before any retrieval change; the answer-quality gate
+must pass before M6.
+
+| Milestone | Phase | Track | Estimate |
+| --- | --- | --- | --- |
+| M1 Shared core package | 1 | Delivery | **Done 2026-07-31** |
+| M2 Evaluation harness + golden set | 1 | Quality | 2–3 days |
+| M3 Backend service | 2 | Delivery | 2–4 days |
+| M4 Documentation widget | 2 | Delivery | 3–5 days |
+| M5 Deployment + index pipeline | 2 | Delivery | 2–3 days |
+| M6 Launch hardening | 2 | Both | 1–2 days |
+| M7 Retrieval upgrades | 3 | Quality | 1–2 weeks |
+| M8 In-platform surface | 4 | Delivery | ~1 week, staged |
+
+Dependencies: M1 → M2 and M3; M3 → M4 (the widget develops against a local
+service); M5 can start alongside M4; M6 needs M2, M4, M5; M8 follows M6 and
+leans on M4's embeddable-module constraint; stages A1–A4 (Phase 5) follow
+M8.2. Elapsed time to a public beta (end of Phase 2): roughly two to three
+weeks of focused work.
+
+---
+
+## 4. Milestones
+
+### M1. Shared core package — **done 2026-07-31**
+
+The demo became the installable package the service will import, per
+[web delivery plan §3.1](docs-agent-web-delivery.md) ("refactor first"), in
+the `documentation-agent` repository (D6):
+
+```
+pyproject.toml              # mat3ra-docs-agent; [anthropic] and [dev] extras
+mat3ra_docs_agent/
+  config.py                 # environment-driven settings
+  ingest.py                 # chunker; --docs-root points at a docs checkout
+  retriever.py              # Retriever, tokenize, format_results
+  prompt.py                 # SYSTEM_PROMPT, SEARCH_TOOL
+  providers/                # base, gemini_vertex, anthropic_vertex
+  loop.py                   # run_turn, provider-agnostic
+  cli.py                    # docs-agent, docs-agent-ingest
+tests/                      # 42 tests, offline
+.github/workflows/tests.yml # pytest on 3.10 and 3.12
+```
+
+Beyond the original scope, the model backend was abstracted (D5): `Provider`
+exposes `add_user_message` / `add_tool_results` / `generate` over neutral
+types, each adapter holding the conversation in its own native format. The
+loop never sees a vendor dialect, which is what makes the Gemini-now,
+Claude-later switch a one-line change.
+
+Verified: 42 offline tests pass; ingestion reproduces the demo exactly (534
+pages → 2,554 chunks); a live query on Gemini returns the same two-method
+POSCAR answer with the same citations as the original demo.
+
+Two findings worth carrying forward:
+
+- **BM25 needs a realistic corpus.** Inverse document frequency is
+  meaningless over one document — scores go non-positive and the relevance
+  filter drops everything. Test fixtures use several pages; the M2 harness
+  must not evaluate against toy corpora.
+- **Gemini 3.x spends thinking tokens before emitting a tool call.** A small
+  output budget starves the call and produces an empty turn, so
+  `MAX_OUTPUT_TOKENS` is 8192.
+
+### M2. Evaluation harness and golden set (`documentation-agent` repository)
+
+The tuning loop from [RAG plan §5](docs-agent-rag.md). Layout:
+
+```
+eval/
+  golden.yaml          # question, expected page URL(s), key facts, answerable: bool
+  eval_retrieval.py    # recall@5, MRR — no model calls
+  eval_answers.py      # model-as-judge: faithfulness, citation validity, completeness
+  README.md            # how to run; the recorded BM25 baseline
+```
+
+Work items:
+
+1. Seed `golden.yaml` with ~30 entries (tutorial steps rephrased, pricing and
+   accounts FAQs, REST API usage, plus 5 unanswerable questions); grow toward
+   75–100 using logged real questions after launch (D7).
+2. `eval_retrieval.py` runs in seconds and prints per-question hits; record
+   the BM25 baseline in the eval README and set D8 thresholds from it.
+   Evaluate against the full index — never a toy corpus (M1 finding).
+3. `eval_answers.py` runs on demand (Vertex has no Batch API — standard
+   rates, so it is not a per-PR gate; retrieval metrics are). It is also
+   where the Gemini/Claude and model-tier comparison gets settled (D5).
+4. CI: retrieval evaluation runs on every pull request; a threshold
+   regression fails the check. It needs the index, so the workflow ingests
+   from a documentation checkout first.
+
+Acceptance: baseline numbers committed; a deliberate retrieval regression
+(e.g. top-k = 1) fails CI.
+
+### M3. Backend service (`documentation-agent` repository, D2)
+
+FastAPI wrapper around the core package, per [web delivery plan §3.1](docs-agent-web-delivery.md).
+
+Work items:
+
+1. Repository skeleton: `app/main.py`, `Dockerfile`, `README.md`, CI.
+2. `POST /chat` — request: message history (client-held, no server session
+   store); response: server-sent events — `text` deltas, `status` events
+   while a search runs ("Searching documentation…"), one final `sources`
+   event, then `done`.
+3. Streaming tool loop: add a `run_turn_streaming` generator to
+   `mat3ra_docs_agent.loop`, and a `stream()` method on `Provider`
+   implemented by both adapters, so the CLI and service share one loop.
+4. `GET /health` for the runtime probe.
+5. Guards, all request-tested: CORS allowlist (`https://docs.mat3ra.com`,
+   localhost origins for development), per-IP token-bucket rate limit
+   (in-process is acceptable at beta scale; note it resets on scale-to-zero),
+   caps on message count and body size per request, the existing 8-iteration
+   tool bound, and a per-conversation output-token ceiling.
+6. Structured request logs per D7: latency, tool calls, token usage, stop
+   reason — the observability list from [web delivery plan §6](docs-agent-web-delivery.md).
+
+Acceptance: `docker run` locally with ADC answers a question end-to-end with
+visible streaming; a scripted client verifies each guard (rejected origin,
+rate-limit 429, oversized body 413).
+
+### M4. Documentation widget (this repository)
+
+Embeddable chat on every page of the documentation sites, per
+[web delivery plan §3.2](docs-agent-web-delivery.md). Note the site count has
+grown past the four in `AGENTS.md`: CI now builds eight (adding Interface,
+Resources, Developers, Command Line, Standards), so verify the widget against
+the workflow's list rather than a remembered number.
+
+Work items:
+
+1. New assets, self-hosted (no CDN):
+
+   ```
+   lang/en/docs/extra/js/docs-agent.js        # launcher, panel, SSE client, renderer
+   lang/en/docs/extra/css/docs-agent.css
+   lang/en/docs/extra/js/vendor/              # marked + DOMPurify, pinned versions
+   ```
+
+   `docs-agent.js` is written as a framework-free embeddable module —
+   `DocsAgent.mount(element, {endpoint, tokenProvider})`, themed through CSS
+   custom properties, no MkDocs assumptions — so the platform surface (M8)
+   reuses it through a thin wrapper rather than a rewrite.
+
+2. Wire into `mkdocs-base.yml` (`extra_javascript`, `extra_css`). All four
+   site configs `INHERIT` the base, so this is a single edit — verify each
+   built site picks it up rather than editing four files.
+3. Behaviour: floating "Ask AI" launcher; panel with conversation held in
+   memory only; streamed Markdown rendered incrementally and sanitised
+   (DOMPurify) — model output is never injected as raw HTML; searching
+   indicator driven by `status` events; `sources` rendered as links; footer
+   with the D7 disclosure and an escalation link to support.
+4. Endpoint constant in `docs-agent.js` (D4 URL), with a `localStorage`
+   override for local development against `localhost`. If the endpoint is
+   unreachable or CORS-blocked (e.g. Netlify deploy previews), the launcher
+   hides — the widget must never break a documentation page.
+5. Keyboard and mobile pass: focus trap in the panel, Escape closes,
+   usable at phone widths.
+
+Acceptance: `./scripts/serve-all.sh` + local service answers with citations
+from any page of all four sites; `scripts/links/check-links.py` still passes;
+widget absent-but-silent when the service is down; the module also mounts in
+a bare HTML page with a single `mount()` call (the M8 embeddability check).
+
+### M5. Deployment and index pipeline
+
+Cloud Run runtime plus the two decoupled triggers from
+[web delivery plan §5.1](docs-agent-web-delivery.md).
+
+Work items:
+
+1. One-time cloud setup (D3): runtime service account with Vertex model
+   access and read access to the index bucket, nothing else; Workload
+   Identity Federation for both repositories' GitHub Actions — no key files
+   anywhere; budget on the project — **done 2026-07-31**: $100/month,
+   alerts at 50/80/100%, and the console's native spend cap (pauses
+   services on breach) configured. Costs are recorded with up to ~24 hours
+   of lag, so the cap is a backstop, not burst protection: Cloud Run
+   `--max-instances` times the per-request token caps (M3.5) still bounds
+   the worst-case burn rate, and Vertex per-model quotas can be lowered as
+   a second bound.
+2. Documentation trigger — small workflow in this repository: on push to
+   `main` touching `lang/en/docs/**`, fire a `repository_dispatch` carrying
+   the documentation SHA. It runs no ingestion; under D6 all agent logic
+   lives in the service repository.
+3. Service pipeline (service repository): on dispatch or own-repo push,
+   check out the documentation at that SHA, ingest, build the image
+   **baking in** the resulting index and the documentation SHA, deploy to a
+   staging revision, smoke-test (`/health` plus one golden question), then
+   promote. Rollback = redeploy the previous image, which carries its own
+   index.
+4. Runtime settings: scale-to-zero, small instance, concurrency tuned for
+   SSE; request timeout above the slowest multi-search answer observed.
+
+Acceptance: a trivial documentation edit on `main` propagates to a redeployed
+service without manual steps; rollback drill performed once; spend alert
+fires on a test threshold.
+
+### M6. Launch hardening
+
+Gate on all of: D7 signed off, D8 thresholds met on the golden set
+(including ≥ 90% correct behaviour on the unanswerable subset), M3 guard
+tests green, M5 rollback drill done.
+
+Work items:
+
+1. Decide and publish the privacy note (widget footer; optionally a short
+   documentation page — which adds a `mkdocs.yml` nav entry in the same
+   change, per repository convention).
+2. Re-run the full answer-quality evaluation against the production
+   endpoint, not just locally.
+3. Enable the widget on production by shipping the `mkdocs-base.yml` change
+   (until then, the widget branch stays unmerged — the docs deploy on push
+   to `main` via `s3-deploy.yml`, so merging is launching).
+4. Soft launch: announce internally, watch logs and spend for a week, then
+   announce publicly.
+
+### M7. Post-launch retrieval upgrades (quality track)
+
+In the order and for the reasons given in [RAG plan §4.3](docs-agent-rag.md),
+every step gated on the M2 harness: inline `--8<--` ESSE includes; contextual
+retrieval; embeddings + hybrid search (behind the same `Retriever.search`
+interface — no service change); `get_page` tool; reranking only if the
+numbers justify it; model-tier comparison for cost (D5).
+
+### M8. In-platform surface (platform.mat3ra.com)
+
+The second surface from [web delivery plan §2.2](docs-agent-web-delivery.md). The platform
+reuses the deployed service and the embeddable widget; retrieval, the agent
+loop, and model credentials never enter the platform application (rejected in
+[web delivery plan §2.1](docs-agent-web-delivery.md)).
+
+Reuse boundaries:
+
+- **Backend — reused as deployed.** The platform calls the same service and
+  `/chat` contract; there is no second deployment and nothing is ported to
+  Node. The browser talks to the service directly — the platform never
+  proxies the SSE stream (Meteor methods are RPC; the streaming mismatch was
+  §2.1's decisive row). Service change: the platform origin joins the CORS
+  allowlist.
+- **Frontend — reused as a module.** A thin React wrapper (a ref plus
+  `DocsAgent.mount()`, ~20 lines) hosts the M4 widget inside the platform
+  shell. The service serves its own built copy of the bundle
+  (`GET /widget.js`, copied from this repository during the M5 image build),
+  so the client the platform loads is version-locked to the API it calls; a
+  pinned vendored copy in the platform repository is the fallback if loading
+  a service-hosted script is unwanted there.
+- **Deliberately not reused:** no Vertex credentials in the platform, and no
+  platform-action tools in M8 itself — those are specified in
+  [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) behind
+  their own security review.
+
+Stages, each independently shippable:
+
+1. **M8.1 — anonymous embed (1–2 days, platform repository).** A
+   feature-flagged launcher mounts the widget against the production
+   endpoint. Platform users are treated like documentation visitors
+   (per-IP limits). Can ship any time after M6.
+2. **M8.2 — user identity via OIDC (1–2 days, mostly service-side).** The
+   platform already authenticates through OpenID Connect, so no token
+   endpoint is built: `tokenProvider` returns the signed-in user's ID
+   token, and the service validates it against the identity provider's
+   published keys (JWKS), checking audience and expiry — no shared secrets
+   to provision or rotate. Verified callers switch from per-IP to
+   per-account rate limits, with user context logged. Extends D7 —
+   retention for identified questions must be decided before M8.2 ships.
+   This identity gate is what the platform-actions capability
+   ([`docs-agent-platform-actions.md`](docs-agent-platform-actions.md))
+   builds on.
+3. **M8.3 — context hints (~1 day).** The wrapper passes the current platform
+   view (route or screen name) as a request field folded into the prompt, so
+   answers orient to where the user is. Client-supplied hints only — no
+   privileged data path.
+
+Acceptance: M8.1 answers with citations inside the platform behind the flag;
+under M8.2, two accounts on one address get independent rate budgets while
+anonymous callers stay IP-limited; the same widget keeps working unchanged
+on docs.mat3ra.com throughout.
+
+---
+
+## 5. Change inventory by location
+
+| Location | Changes |
+| --- | --- |
+| This repository (public) | Widget assets + `mkdocs-base.yml` wiring (M4); documentation-merge trigger (M5.2); privacy page if chosen (M6). The superseded Phase-0 demo still sits in `scripts/rag/` |
+| Service repository ([`documentation-agent`](https://github.com/mat3ra/documentation-agent), private) | Core package (M1, done); eval harness (M2); FastAPI app, streaming loop, Dockerfile, guards, deploy pipeline (M3, M5.3); serves the widget bundle, verifies platform tokens, per-account limits (M8) |
+| Platform repository (`web-app`, existing) | React wrapper + feature flag (M8.1); OIDC token wiring (M8.2); context hints (M8.3) |
+| Google Cloud (one-time) | Service account, WIF, index bucket, budget alert, Cloud Run service (M5.1) |
+
+## 6. Execution risks
+
+Strategy risks live in the companions ([RAG plan §8](docs-agent-rag.md),
+[web delivery plan §6](docs-agent-web-delivery.md)); these are risks to the execution:
+
+- **The public endpoint exists before launch** (M5 precedes M6). Keep the
+  staging service unlisted, CORS-locked, and rate-limited from its first
+  deploy; the widget merge, not the service deploy, is the launch event.
+- **Model deprecation on Vertex.** The pinned id will eventually retire, and
+  one default (`gemini-3.1-pro-preview`) is explicitly a preview. The M2
+  harness is the safety net — upgrade is a config change plus an evaluation
+  run, never a silent bump. Model availability is also region-specific
+  (Gemini 3.x is `global`-only today), so region and model move together.
+- **Golden-set staleness.** Documentation moves; expected-URL entries rot.
+  The retrieval evaluation doubles as the detector (a moved page drops
+  recall), and D7 logs supply replacement questions.
+- **Single-maintainer bandwidth.** Milestones are cut to merge
+  independently: each of M1–M5 leaves `main` shippable, and the plan
+  survives being picked up and put down between sessions.
+
+## 7. Immediate next actions
+
+1. **Commit and push M1** to `documentation-agent` (built and verified
+   locally 2026-07-31, not yet pushed).
+2. **M2 harness** in the same repository: the ~30-question seed, the
+   recorded BM25 baseline, D8 thresholds.
+3. **Retire the superseded demo** in `scripts/rag/` once M1 is pushed, so
+   there is one implementation rather than two.
+4. **Owner, when convenient:** enable the Claude models in Model Garden on
+   `mat3ra-documentation` to unblock the `anthropic` backend for the D5
+   comparison. Nothing is blocked on it — Gemini is the default and works.

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -5,9 +5,8 @@ The companion documents hold the reasoning; this one holds the work: milestones,
 file-level work items, acceptance criteria, and the decisions still open.
 
 - **Status:** Active, living document — §3 is the initiative's progression
-  tracker. Phase 1 is complete and Phase 2 is under way: the service and the
-  widget are built and verified end to end locally; deployment (M5) and
-  launch hardening (M6) remain.
+  tracker. M1–M5 are done: the agent is deployed and answering on Cloud Run.
+  Only the launch gate (M6) stands between here and a public beta.
 - **Last updated:** 2026-07-31
 - **Companion plans:** [`docs-agent-rag.md`](docs-agent-rag.md) (retrieval and
   evaluation strategy), [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md)
@@ -37,12 +36,12 @@ later milestone but nothing before it.
 | --- | --- | --- | --- |
 | D1 | Runtime | Cloud Run, same project as Vertex access ([web delivery plan §5](docs-agent-web-delivery.md), Option A) | Adopted |
 | D2 | Service code location | Private repository [`mat3ra/documentation-agent`](https://github.com/mat3ra/documentation-agent), pinned into the platform stack later if wanted | **Adopted** — repository created 2026-07-31 |
-| D3 | Google Cloud project | Dedicated project `mat3ra-documentation` with spend controls per M5.1 | **Adopted** — project created with budget and native spend cap (2026-07-31); Vertex AI API + Claude Model Garden enablement to confirm end-to-end |
+| D3 | Google Cloud project | Dedicated project `mat3ra-documentation` with spend controls per M5.1 | **Done 2026-07-31** — project, budget and native spend cap in place; Vertex AI enabled and confirmed end to end from Cloud Run. Claude Model Garden enablement is still outstanding and blocks only the D5 comparison |
 | D4 | Public endpoint | Default `*.run.app` URL for beta; a `mat3ra.com` subdomain before general availability | Beta default adopted |
 | D5 | Model | Provider abstraction over Vertex: **Gemini by default** (`gemini-3.6-flash`, `global`), Claude (`claude-opus-4-6`, `us-east5`) behind the same interface once Model Garden is enabled. Tier changes only through the evaluation harness | **Revised 2026-07-31** — Gemini needs no Model Garden step, so it unblocks work today; the abstraction keeps the choice reversible |
 | D6 | Core package location | The agent core (ingestion, retrieval, prompt, loop) lives in the **`documentation-agent` repository**; this repository provides the corpus only. Ingestion reads a documentation checkout via `--docs-root` | **Revised 2026-07-31** — supersedes the earlier "core stays in `scripts/rag/`" split; one repository owns all agent code, so there is no cross-repository package dependency to keep in step |
 | D7 | Logging and retention | Store question, tool trace, answer, and token counts for 30 days to seed the golden set; no IP addresses joined to content; disclosed in the widget footer | Needs sign-off before launch |
-| D8 | Launch quality bar | Regression gate set just below the measured BM25 baseline: **recall@5 ≥ 0.65, MRR ≥ 0.50** (baseline 0.688 / 0.543), plus zero hallucinated URLs. Refusal on the unanswerable subset is **0.80 today and must reach 1.00 before launch** | **Set 2026-07-31** from measurement, not aspiration |
+| D8 | Launch quality bar | Regression gate set just below the measured BM25 baseline: **recall@5 ≥ 0.65, MRR ≥ 0.50** (baseline 0.688 / 0.543), plus zero hallucinated URLs. Refusal on the unanswerable subset must be **1.00**, reached 2026-07-31 after the prompt revision | **Set 2026-07-31** from measurement, not aspiration |
 
 ## 3. Phases and workstreams
 
@@ -53,7 +52,7 @@ authority):
 | --- | --- | --- | --- |
 | 0 | Prototypes | BM25 demo in `scripts/rag/`; desktop automation experiment in the platform repository ([`web-app#2894`](https://github.com/mat3ra/web-app/pull/2894)) | **Done** |
 | 1 | Foundations | M1 core package, M2 evaluation harness | **Done 2026-07-31** |
-| 2 | Docs launch | M3 service, M4 widget, M5 deployment, M6 hardening | In progress — M3 and M4 done 2026-07-31; M5 next |
+| 2 | Docs launch | M3 service, M4 widget, M5 deployment, M6 hardening | In progress — M3–M5 done 2026-07-31; M6 (launch gate) remains |
 | 3 | Retrieval quality | M7 upgrades, evaluation-gated | Planned, post-launch |
 | 4 | Platform embed | M8, stages M8.1–M8.3 | Planned, post-launch |
 | 5 | Platform actions | Stages A1–A4 in [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) | Proposed |
@@ -77,7 +76,7 @@ must pass before M6.
 | M2 Evaluation harness + golden set | 1 | Quality | **Done 2026-07-31** |
 | M3 Backend service | 2 | Delivery | **Done 2026-07-31** |
 | M4 Documentation widget | 2 | Delivery | **Done 2026-07-31** |
-| M5 Deployment + index pipeline | 2 | Delivery | 2–3 days |
+| M5 Deployment + index pipeline | 2 | Delivery | **Done 2026-07-31** |
 | M6 Launch hardening | 2 | Both | 1–2 days |
 | M7 Retrieval upgrades | 3 | Quality | 1–2 weeks |
 | M8 In-platform surface | 4 | Delivery | ~1 week, staged |
@@ -268,7 +267,44 @@ from any page of all four sites; `scripts/links/check-links.py` still passes;
 widget absent-but-silent when the service is down; the module also mounts in
 a bare HTML page with a single `mount()` call (the M8 embeddability check).
 
-### M5. Deployment and index pipeline
+### M5. Deployment and index pipeline — **done 2026-07-31**
+
+Live at `https://docs-agent-mmrcocqy3a-uc.a.run.app` (D4: the default Cloud
+Run hostname for the beta). The Cloud Run choice paid off exactly where §5
+said it would — the attached service account supplies Vertex credentials, so
+the pasted access token that development needed is not managed, it is gone.
+
+Two identities, deliberately separate: the runtime holds only Vertex access,
+and the deploy identity may act as it without inheriting anything from it.
+CI authenticates through Workload Identity Federation, so no service-account
+key exists in either place.
+
+A revision deploys with **no traffic** behind a `candidate` tag, is
+smoke-tested on its own URL for health and one real end-to-end question, and
+only then takes traffic. A broken revision never gets the chance to serve.
+
+Verified against the deployed service, not locally: health reports the
+documentation commit its index was built from; an anonymous request streams a
+grounded answer; the CORS allowlist admits the documentation origin and
+refuses another; an oversized body is rejected; and the rollback drill ran end
+to end — promote, roll back to the previous revision, roll forward — with the
+traffic split confirmed at each step.
+
+Three things worth carrying forward:
+
+- **`git clone --branch` cannot take a commit SHA.** Pinning the index to a
+  documentation commit failed outright until the build was changed to fetch
+  the ref and check out `FETCH_HEAD`. Pinning is the whole point of the
+  artifact, so this would have silently degraded to "whatever `main` was".
+- **`builds submit --tag` cannot pass a build argument**, which the pinned
+  build needs; an explicit build config replaces it.
+- **A brand-new project needs a moment.** The first `run deploy --source`
+  failed with a bare permission error that resolved itself once the freshly
+  created Artifact Registry repository and its permissions had propagated —
+  worth knowing before chasing an org policy that is not the cause.
+
+The original plan for this milestone follows, for the reasoning behind the
+shape above.
 
 Cloud Run runtime plus the two decoupled triggers from
 [web delivery plan §5.1](docs-agent-web-delivery.md).
@@ -416,22 +452,28 @@ Strategy risks live in the companions ([RAG plan §8](docs-agent-rag.md),
 
 ## 7. Immediate next actions
 
-M1–M4 are built and verified locally. What stands between here and a public
-beta is deployment and the launch gate, not features.
+M1–M5 are done and the agent is deployed and answering. Only the launch gate
+remains, and most of what is left is judgement rather than code.
 
 1. **Merge the open pull requests.** They are stacked and merge in order:
-   `documentation-agent` #1 (M1) → #2 (M2) → #3 (M3); `documentation` #391
-   (plans) and the widget branch after #389.
-2. **M5, deployment.** The one remaining piece with unknowns in it: the
-   Cloud Run service, Workload Identity Federation for both repositories,
-   the documentation-merge trigger, and the rollback drill. The widget's
-   endpoint constant points at a host that does not exist yet, which is
-   safe — the launcher stays hidden — but it is the last wire to connect.
+   `documentation-agent` #1 (M1) → #2 (M2) → #3 (M3) → #4 (M5);
+   `documentation` #391 after #389.
+2. **D7, the retention decision** (owner). It gates M6 and nothing else is
+   blocking it. The widget footer already discloses that questions are
+   logged, so the text and the policy need to agree before anyone sees it.
 3. **Settle the faithfulness measurement** before M6 can gate on it. One run
    cannot separate a prompt change from sampling noise (§M2), so either
    repeat the run or grow the set.
-4. **Retire the superseded demo** in `scripts/rag/` so there is one
+4. **Two secrets to add:** `DOCS_AGENT_DISPATCH_TOKEN` in this repository, so
+   a documentation merge triggers a rebuild; the pipeline skips with a
+   message until then, rather than failing the build.
+5. **Retire the superseded demo** in `scripts/rag/` so there is one
    implementation rather than two.
-5. **Owner, when convenient:** enable the Claude models in Model Garden on
+6. **Owner, when convenient:** enable the Claude models in Model Garden on
    `mat3ra-documentation` to unblock the `anthropic` backend for the D5
    comparison. Nothing is blocked on it — Gemini is the default and works.
+
+Note what merging does and does not do. The widget only appears once the
+service answers its health check, and the service is already live, so
+**merging the widget to `main` is the launch** — which is why it waits on
+M6 rather than on anything technical.

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -487,13 +487,19 @@ remains, and most of what is left is judgement rather than code.
 4. **Two secrets to add:** `DOCS_AGENT_DISPATCH_TOKEN` in this repository, so
    a documentation merge triggers a rebuild; the pipeline skips with a
    message until then, rather than failing the build.
-5. **Upgrade the local Google Cloud SDK.** It is still 437.0.1 (June 2023),
-   and Google rejects that client's token refresh: a fresh `gcloud auth
-   login` works for about an hour and then every call fails with
-   `ACCESS_TOKEN_TYPE_UNSUPPORTED`. Re-authenticating treats the symptom
-   hourly; `brew upgrade` fixes it. Nothing deployed depends on it — Cloud
-   Run uses its own service account — but no deploy can be run from a laptop
-   in this state.
+5. **The build machine's gcloud is sorted — the story is worth recording.**
+   The failures were three stacked causes, not one: the machine driving
+   builds (Mat3rium) is a different computer from the laptop whose logins
+   kept "not helping"; its 2023-era gcloud minted tokens Google began
+   rejecting outright on 2026-08-01; and its account session now demands
+   interactive reauthentication, which no non-interactive shell can
+   satisfy. Current state: a current SDK runs from a local directory, fed
+   tokens minted from application-default credentials
+   (`CLOUDSDK_AUTH_ACCESS_TOKEN`), which refresh fine — no user action
+   needed per deploy. A proper `gcloud auth login` on Mat3rium plus a brew
+   upgrade there would retire the workaround; deploys through CI (federated
+   identity) bypass all of it, which is one more reason to merge the
+   pipeline.
 5. **Retire the superseded demo** in `scripts/rag/` so there is one
    implementation rather than two.
 6. **Owner, when convenient:** enable the Claude models in Model Garden on

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -5,8 +5,9 @@ The companion documents hold the reasoning; this one holds the work: milestones,
 file-level work items, acceptance criteria, and the decisions still open.
 
 - **Status:** Active, living document — §3 is the initiative's progression
-  tracker. Phase 1 (core package, evaluation harness) is complete; Phase 2
-  (the docs launch) is next.
+  tracker. Phase 1 is complete and Phase 2 is under way: the service and the
+  widget are built and verified end to end locally; deployment (M5) and
+  launch hardening (M6) remain.
 - **Last updated:** 2026-07-31
 - **Companion plans:** [`docs-agent-rag.md`](docs-agent-rag.md) (retrieval and
   evaluation strategy), [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md)
@@ -52,7 +53,7 @@ authority):
 | --- | --- | --- | --- |
 | 0 | Prototypes | BM25 demo in `scripts/rag/`; desktop automation experiment in the platform repository ([`web-app#2894`](https://github.com/mat3ra/web-app/pull/2894)) | **Done** |
 | 1 | Foundations | M1 core package, M2 evaluation harness | **Done 2026-07-31** |
-| 2 | Docs launch | M3 service, M4 widget, M5 deployment, M6 hardening | Planned |
+| 2 | Docs launch | M3 service, M4 widget, M5 deployment, M6 hardening | In progress — M3 and M4 done 2026-07-31; M5 next |
 | 3 | Retrieval quality | M7 upgrades, evaluation-gated | Planned, post-launch |
 | 4 | Platform embed | M8, stages M8.1–M8.3 | Planned, post-launch |
 | 5 | Platform actions | Stages A1–A4 in [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) | Proposed |
@@ -74,8 +75,8 @@ must pass before M6.
 | --- | --- | --- | --- |
 | M1 Shared core package | 1 | Delivery | **Done 2026-07-31** |
 | M2 Evaluation harness + golden set | 1 | Quality | **Done 2026-07-31** |
-| M3 Backend service | 2 | Delivery | 2–4 days |
-| M4 Documentation widget | 2 | Delivery | 3–5 days |
+| M3 Backend service | 2 | Delivery | **Done 2026-07-31** |
+| M4 Documentation widget | 2 | Delivery | **Done 2026-07-31** |
 | M5 Deployment + index pipeline | 2 | Delivery | 2–3 days |
 | M6 Launch hardening | 2 | Both | 1–2 days |
 | M7 Retrieval upgrades | 3 | Quality | 1–2 weeks |
@@ -415,16 +416,20 @@ Strategy risks live in the companions ([RAG plan §8](docs-agent-rag.md),
 
 ## 7. Immediate next actions
 
-Phase 1 is complete; Phase 2 (docs launch) is next.
+M1–M4 are built and verified locally. What stands between here and a public
+beta is deployment and the launch gate, not features.
 
-1. **Tighten the system prompt** against the two defects M2 found — the
-   refusal rule and the ban on inventing UI element names — and re-measure.
-   This is the first pass through the tuning loop and it now has numbers to
-   beat, so it comes before new features.
-2. **Merge the open pull requests** — `documentation-agent` #1 (M1) then #2
-   (M2); `documentation` #391 (plans) after #389.
-3. **M3, the backend service:** FastAPI `/chat` with SSE streaming, the
-   guards from §M3, reusing the core package.
+1. **Merge the open pull requests.** They are stacked and merge in order:
+   `documentation-agent` #1 (M1) → #2 (M2) → #3 (M3); `documentation` #391
+   (plans) and the widget branch after #389.
+2. **M5, deployment.** The one remaining piece with unknowns in it: the
+   Cloud Run service, Workload Identity Federation for both repositories,
+   the documentation-merge trigger, and the rollback drill. The widget's
+   endpoint constant points at a host that does not exist yet, which is
+   safe — the launcher stays hidden — but it is the last wire to connect.
+3. **Settle the faithfulness measurement** before M6 can gate on it. One run
+   cannot separate a prompt change from sampling noise (§M2), so either
+   repeat the run or grow the set.
 4. **Retire the superseded demo** in `scripts/rag/` so there is one
    implementation rather than two.
 5. **Owner, when convenient:** enable the Claude models in Model Garden on

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -39,7 +39,7 @@ later milestone but nothing before it.
 | D5 | Model | Provider abstraction over Vertex: **Gemini by default** (`gemini-3.6-flash`, `global`), Claude (`claude-opus-4-6`, `us-east5`) behind the same interface once Model Garden is enabled. Tier changes only through the evaluation harness | **Revised 2026-07-31** — Gemini needs no Model Garden step, so it unblocks work today; the abstraction keeps the choice reversible |
 | D6 | Core package location | The agent core (ingestion, retrieval, prompt, loop) lives in the **`documentation-agent` repository**; this repository provides the corpus only. Ingestion reads a documentation checkout via `--docs-root` | **Revised 2026-07-31** — supersedes the earlier "core stays in `scripts/rag/`" split; one repository owns all agent code, so there is no cross-repository package dependency to keep in step |
 | D7 | Logging and retention | Store question, tool trace, answer, and token counts for 30 days to seed the golden set; no IP addresses joined to content; disclosed in the widget footer | Needs sign-off before launch |
-| D8 | Launch quality bar | Thresholds set from the measured BM25 baseline (M2), not chosen aspirationally | Set during M2 |
+| D8 | Launch quality bar | Regression gate set just below the measured BM25 baseline: **recall@5 ≥ 0.65, MRR ≥ 0.45** (baseline 0.688 / 0.494), plus zero hallucinated URLs and correct refusal on the unanswerable subset | **Set 2026-07-31** from measurement, not aspiration |
 
 ## 3. Phases and workstreams
 
@@ -49,7 +49,7 @@ authority):
 | Phase | Name | Contents | State |
 | --- | --- | --- | --- |
 | 0 | Prototypes | BM25 demo in `scripts/rag/`; desktop automation experiment in the platform repository ([`web-app#2894`](https://github.com/mat3ra/web-app/pull/2894)) | **Done** |
-| 1 | Foundations | M1 core package, M2 evaluation harness | In progress — M1 done 2026-07-31, M2 next |
+| 1 | Foundations | M1 core package, M2 evaluation harness | **Done 2026-07-31** |
 | 2 | Docs launch | M3 service, M4 widget, M5 deployment, M6 hardening | Planned |
 | 3 | Retrieval quality | M7 upgrades, evaluation-gated | Planned, post-launch |
 | 4 | Platform embed | M8, stages M8.1–M8.3 | Planned, post-launch |
@@ -71,7 +71,7 @@ must pass before M6.
 | Milestone | Phase | Track | Estimate |
 | --- | --- | --- | --- |
 | M1 Shared core package | 1 | Delivery | **Done 2026-07-31** |
-| M2 Evaluation harness + golden set | 1 | Quality | 2–3 days |
+| M2 Evaluation harness + golden set | 1 | Quality | **Done 2026-07-31** |
 | M3 Backend service | 2 | Delivery | 2–4 days |
 | M4 Documentation widget | 2 | Delivery | 3–5 days |
 | M5 Deployment + index pipeline | 2 | Delivery | 2–3 days |
@@ -129,35 +129,47 @@ Two findings worth carrying forward:
   output budget starves the call and produces an empty turn, so
   `MAX_OUTPUT_TOKENS` is 8192.
 
-### M2. Evaluation harness and golden set (`documentation-agent` repository)
+### M2. Evaluation harness and golden set — **done 2026-07-31**
 
-The tuning loop from [RAG plan §5](docs-agent-rag.md). Layout:
+The tuning loop from [RAG plan §5](docs-agent-rag.md), in the
+`documentation-agent` repository under `eval/`: `golden.yaml`, a free
+retrieval harness, a paid answer harness, and a README carrying the
+baseline.
 
-```
-eval/
-  golden.yaml          # question, expected page URL(s), key facts, answerable: bool
-  eval_retrieval.py    # recall@5, MRR — no model calls
-  eval_answers.py      # model-as-judge: faithfulness, citation validity, completeness
-  README.md            # how to run; the recorded BM25 baseline
-```
+The golden set holds 38 questions — 33 answerable and 5 the documentation
+deliberately cannot answer, scored separately, because an assistant that
+scores well elsewhere and improvises on those is worse than useless.
+Questions are phrased as a user would ask them rather than as the pages are
+written. Expected pages are validated against the index before every run, so
+a renamed page fails the run instead of quietly depressing the metrics.
 
-Work items:
+**Recorded BM25 baseline** (33 answerable questions, 534 pages / 2,554
+chunks):
 
-1. Seed `golden.yaml` with ~30 entries (tutorial steps rephrased, pricing and
-   accounts FAQs, REST API usage, plus 5 unanswerable questions); grow toward
-   75–100 using logged real questions after launch (D7).
-2. `eval_retrieval.py` runs in seconds and prints per-question hits; record
-   the BM25 baseline in the eval README and set D8 thresholds from it.
-   Evaluate against the full index — never a toy corpus (M1 finding).
-3. `eval_answers.py` runs on demand (Vertex has no Batch API — standard
-   rates, so it is not a per-PR gate; retrieval metrics are). It is also
-   where the Gemini/Claude and model-tier comparison gets settled (D5).
-4. CI: retrieval evaluation runs on every pull request; a threshold
-   regression fails the check. It needs the index, so the workflow ingests
-   from a documentation checkout first.
+| recall@1 | recall@3 | recall@5 | recall@10 | MRR |
+| --- | --- | --- | --- | --- |
+| 0.344 | 0.562 | 0.688 | 0.875 | 0.494 |
 
-Acceptance: baseline numbers committed; a deliberate retrieval regression
-(e.g. top-k = 1) fails CI.
+For about a third of questions the top hit is already right; for about a
+third the right page is not in the top five. The failures are precisely the
+paraphrase weakness §4.3 predicted — "How does authentication work for the
+REST API?" ranks the *JupyterLite* authentication page first — which is the
+concrete case hybrid retrieval (M7) has to beat.
+
+Two things this measurement establishes:
+
+- **The numbers are a lower bound on the agent, not a verdict on it.** The
+  agent reformulates and re-searches, so a page at rank 8 for the user's
+  original phrasing is often still cited correctly — verified on the REST API
+  question. Retrieval recall is a leading indicator.
+- **Answer evaluation separates the deterministic from the judged.** Every
+  cited URL must exist in the corpus; that check cannot itself hallucinate,
+  so it is reported on its own and any failure fails the run, independent of
+  a judge's opinion.
+
+CI gates every pull request on the retrieval metrics at the D8 thresholds;
+the answer harness runs on demand (no Batch API on Vertex) and is where the
+Gemini/Claude and model-tier comparison gets settled (D5).
 
 ### M3. Backend service (`documentation-agent` repository, D2)
 
@@ -377,12 +389,14 @@ Strategy risks live in the companions ([RAG plan §8](docs-agent-rag.md),
 
 ## 7. Immediate next actions
 
-1. **Commit and push M1** to `documentation-agent` (built and verified
-   locally 2026-07-31, not yet pushed).
-2. **M2 harness** in the same repository: the ~30-question seed, the
-   recorded BM25 baseline, D8 thresholds.
-3. **Retire the superseded demo** in `scripts/rag/` once M1 is pushed, so
-   there is one implementation rather than two.
+Phase 1 is complete; Phase 2 (docs launch) is next.
+
+1. **Merge the open pull requests** — `documentation-agent` #1 (M1) then #2
+   (M2); `documentation` #391 (plans) after #389.
+2. **M3, the backend service:** FastAPI `/chat` with SSE streaming, the
+   guards from §M3, reusing the core package.
+3. **Retire the superseded demo** in `scripts/rag/` so there is one
+   implementation rather than two.
 4. **Owner, when convenient:** enable the Claude models in Model Garden on
    `mat3ra-documentation` to unblock the `anthropic` backend for the D5
    comparison. Nothing is blocked on it — Gemini is the default and works.

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -5,7 +5,8 @@ The companion documents hold the reasoning; this one holds the work: milestones,
 file-level work items, acceptance criteria, and the decisions still open.
 
 - **Status:** Active, living document — §3 is the initiative's progression
-  tracker. Nothing beyond Phase 0 (the prototypes) is built.
+  tracker. Phase 1 (core package, evaluation harness) is complete; Phase 2
+  (the docs launch) is next.
 - **Last updated:** 2026-07-31
 - **Companion plans:** [`docs-agent-rag.md`](docs-agent-rag.md) (retrieval and
   evaluation strategy), [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md)
@@ -15,9 +16,10 @@ file-level work items, acceptance criteria, and the decisions still open.
 
 ## 1. Scope and definition of done
 
-Shipped means: an "Ask AI" launcher on every page of all four documentation
-sites opens a chat that streams grounded, cited answers from a production
-service, with abuse limits, spend controls, and an evaluation gate in CI.
+Shipped means: an "Ask AI" launcher on every page of every documentation site
+(eight as of 2026-07-31 — see M4) opens a chat that streams grounded, cited
+answers from a production service, with abuse limits, spend controls, and an
+evaluation gate in CI.
 
 Out of scope for v1: hybrid/vector retrieval beyond an eval-gated upgrade
 (M7), the in-platform "Ask AI" surface (specified in M8, scheduled
@@ -39,7 +41,7 @@ later milestone but nothing before it.
 | D5 | Model | Provider abstraction over Vertex: **Gemini by default** (`gemini-3.6-flash`, `global`), Claude (`claude-opus-4-6`, `us-east5`) behind the same interface once Model Garden is enabled. Tier changes only through the evaluation harness | **Revised 2026-07-31** — Gemini needs no Model Garden step, so it unblocks work today; the abstraction keeps the choice reversible |
 | D6 | Core package location | The agent core (ingestion, retrieval, prompt, loop) lives in the **`documentation-agent` repository**; this repository provides the corpus only. Ingestion reads a documentation checkout via `--docs-root` | **Revised 2026-07-31** — supersedes the earlier "core stays in `scripts/rag/`" split; one repository owns all agent code, so there is no cross-repository package dependency to keep in step |
 | D7 | Logging and retention | Store question, tool trace, answer, and token counts for 30 days to seed the golden set; no IP addresses joined to content; disclosed in the widget footer | Needs sign-off before launch |
-| D8 | Launch quality bar | Regression gate set just below the measured BM25 baseline: **recall@5 ≥ 0.65, MRR ≥ 0.45** (baseline 0.688 / 0.494), plus zero hallucinated URLs and correct refusal on the unanswerable subset | **Set 2026-07-31** from measurement, not aspiration |
+| D8 | Launch quality bar | Regression gate set just below the measured BM25 baseline: **recall@5 ≥ 0.65, MRR ≥ 0.50** (baseline 0.688 / 0.543), plus zero hallucinated URLs. Refusal on the unanswerable subset is **0.80 today and must reach 1.00 before launch** | **Set 2026-07-31** from measurement, not aspiration |
 
 ## 3. Phases and workstreams
 
@@ -136,19 +138,19 @@ The tuning loop from [RAG plan §5](docs-agent-rag.md), in the
 retrieval harness, a paid answer harness, and a README carrying the
 baseline.
 
-The golden set holds 38 questions — 33 answerable and 5 the documentation
+The golden set holds 37 questions — 32 answerable and 5 the documentation
 deliberately cannot answer, scored separately, because an assistant that
 scores well elsewhere and improvises on those is worse than useless.
 Questions are phrased as a user would ask them rather than as the pages are
 written. Expected pages are validated against the index before every run, so
 a renamed page fails the run instead of quietly depressing the metrics.
 
-**Recorded BM25 baseline** (33 answerable questions, 534 pages / 2,554
+**Recorded BM25 baseline** (32 answerable questions, 534 pages / 2,554
 chunks):
 
 | recall@1 | recall@3 | recall@5 | recall@10 | MRR |
 | --- | --- | --- | --- | --- |
-| 0.344 | 0.562 | 0.688 | 0.875 | 0.494 |
+| 0.406 | 0.594 | 0.688 | 0.906 | 0.543 |
 
 For about a third of questions the top hit is already right; for about a
 third the right page is not in the top five. The failures are precisely the
@@ -170,6 +172,30 @@ Two things this measurement establishes:
 CI gates every pull request on the retrieval metrics at the D8 thresholds;
 the answer harness runs on demand (no Batch API on Vertex) and is where the
 Gemini/Claude and model-tier comparison gets settled (D5).
+
+**The answer baseline found two real defects on its first run**, neither
+visible from spot-checking, and both now the immediate tuning work:
+
+| Hallucinated URLs | Cited an expected page | Faithful | Citations support | Completeness | Refused correctly |
+| --- | --- | --- | --- | --- | --- |
+| 0 | 0.906 | 0.892 | 0.973 | 0.959 | **0.800** |
+
+- **Refusal, 4 of 5.** Asked whether the platform is faster than VASP on a
+  64 GB laptop, the agent answered that it is "significantly faster",
+  justified with real hardware specifications. The specifications are
+  documented; the comparative claim is not and cannot be. The dangerous
+  shape is a question *adjacent* to documented material, where retrieval
+  returns something plausible and the model completes the argument itself —
+  which no amount of retrieval improvement fixes.
+- **Faithfulness 0.892.** Four answers invented interface details (a
+  dropdown, a submit button, walltime advice). No URL was ever invented, so
+  half the grounding rule holds and the half covering UI element names does
+  not.
+
+Both are prompt problems, not retrieval problems, and the harness now makes
+the fix measurable rather than a matter of opinion. This is the tuning loop
+working as designed: §8 listed hallucinated UI paths as a risk to be
+"verified by the evaluation judge rather than assumed", and it now has been.
 
 ### M3. Backend service (`documentation-agent` repository, D2)
 
@@ -391,12 +417,16 @@ Strategy risks live in the companions ([RAG plan §8](docs-agent-rag.md),
 
 Phase 1 is complete; Phase 2 (docs launch) is next.
 
-1. **Merge the open pull requests** — `documentation-agent` #1 (M1) then #2
+1. **Tighten the system prompt** against the two defects M2 found — the
+   refusal rule and the ban on inventing UI element names — and re-measure.
+   This is the first pass through the tuning loop and it now has numbers to
+   beat, so it comes before new features.
+2. **Merge the open pull requests** — `documentation-agent` #1 (M1) then #2
    (M2); `documentation` #391 (plans) after #389.
-2. **M3, the backend service:** FastAPI `/chat` with SSE streaming, the
+3. **M3, the backend service:** FastAPI `/chat` with SSE streaming, the
    guards from §M3, reusing the core package.
-3. **Retire the superseded demo** in `scripts/rag/` so there is one
+4. **Retire the superseded demo** in `scripts/rag/` so there is one
    implementation rather than two.
-4. **Owner, when convenient:** enable the Claude models in Model Garden on
+5. **Owner, when convenient:** enable the Claude models in Model Garden on
    `mat3ra-documentation` to unblock the `anthropic` backend for the D5
    comparison. Nothing is blocked on it — Gemini is the default and works.

--- a/plans/docs-agent-implementation.md
+++ b/plans/docs-agent-implementation.md
@@ -41,7 +41,7 @@ later milestone but nothing before it.
 | D5 | Model | Provider abstraction over Vertex: **Gemini by default** (`gemini-3.6-flash`, `global`), Claude (`claude-opus-4-6`, `us-east5`) behind the same interface once Model Garden is enabled. Tier changes only through the evaluation harness | **Revised 2026-07-31** — Gemini needs no Model Garden step, so it unblocks work today; the abstraction keeps the choice reversible |
 | D6 | Core package location | The agent core (ingestion, retrieval, prompt, loop) lives in the **`documentation-agent` repository**; this repository provides the corpus only. Ingestion reads a documentation checkout via `--docs-root` | **Revised 2026-07-31** — supersedes the earlier "core stays in `scripts/rag/`" split; one repository owns all agent code, so there is no cross-repository package dependency to keep in step |
 | D7 | Logging and retention | Store question, tool trace, answer, and token counts for 30 days to seed the golden set; no IP addresses joined to content; disclosed in the widget footer | Needs sign-off before launch |
-| D8 | Launch quality bar | Regression gate set just below the measured BM25 baseline: **recall@5 ≥ 0.65, MRR ≥ 0.50** (baseline 0.688 / 0.543), plus zero hallucinated URLs. Refusal on the unanswerable subset must be **1.00**, reached 2026-07-31 after the prompt revision | **Set 2026-07-31** from measurement, not aspiration |
+| D8 | Launch quality bar | Regression gate set just below the measured BM25 baseline: **recall@5 ≥ 0.65, MRR ≥ 0.50** (baseline 0.688 / 0.543), plus zero hallucinated URLs. Refusal on the unanswerable subset must be **1.00** | **Met with replication 2026-08-01**: refusal 1.00 in four consecutive runs; faithfulness 1.00 in both runs after the judge was corrected to see exactly what the model saw (earlier 0.892 figures were the judge's truncated view, not the agent); zero hallucinated URLs in every run ever made |
 
 ## 3. Phases and workstreams
 
@@ -481,9 +481,11 @@ remains, and most of what is left is judgement rather than code.
 2. **D7, the retention decision** (owner). It gates M6 and nothing else is
    blocking it. The widget footer already discloses that questions are
    logged, so the text and the policy need to agree before anyone sees it.
-3. **Settle the faithfulness measurement** before M6 can gate on it. One run
-   cannot separate a prompt change from sampling noise (§M2), so either
-   repeat the run or grow the set.
+3. ~~Settle the faithfulness measurement~~ — **settled 2026-08-01.** Repeated
+   runs exposed a judge defect (it scored against a truncated view of the
+   evidence); with the corrected judge, faithfulness is 1.00 in both runs.
+   The quality half of the M6 gate is met; what remains of M6 is D7 and the
+   merge itself.
 4. **Two secrets to add:** `DOCS_AGENT_DISPATCH_TOKEN` in this repository, so
    a documentation merge triggers a rebuild; the pipeline skips with a
    message until then, rather than failing the build.

--- a/plans/docs-agent-platform-actions.md
+++ b/plans/docs-agent-platform-actions.md
@@ -1,0 +1,194 @@
+# Documentation Agent — Platform Actions Plan
+
+Plan for letting the in-platform assistant execute actions for the user on
+platform.mat3ra.com, built on the test-automation framework rather than a
+separate action layer. Elaborates Phase 5 of the [RAG plan](docs-agent-rag.md)
+and extends milestone M8 of the
+[implementation plan](docs-agent-implementation.md).
+
+- **Status:** Proposed — needs sign-off and a security review before build.
+  Builds on the working experiment in
+  [mat3ra/web-app#2894](https://github.com/mat3ra/web-app/pull/2894)
+  (`experiment/mcp-server`).
+- **Initiative phase:** 5, staged A1–A4 (numbering per the
+  [implementation plan](docs-agent-implementation.md) §3). Throughout,
+  "the platform repository" means `web-app` — the code behind
+  platform.mat3ra.com.
+- **Last updated:** 2026-07-31
+- **Companion plans:** [`docs-agent-rag.md`](docs-agent-rag.md),
+  [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md),
+  [`docs-agent-implementation.md`](docs-agent-implementation.md)
+
+---
+
+## 1. Principle
+
+The agent may only do what the test suite can prove works, and only what the
+signed-in user could do by hand. Concretely: the action vocabulary **is** the
+Gherkin step library of the end-to-end tests, and execution happens **in the
+user's own browser session**, so the platform's existing authorization
+boundary is never widened.
+
+## 2. What already exists (PR 2894 inventory)
+
+The experiment branch in the platform repository contains a working desktop
+prototype of exactly this capability:
+
+| Piece | Contents | State |
+| --- | --- | --- |
+| `src/tests-cypress/` step definitions | Gherkin steps across ~30 domains (materials, jobs, workflows, billing, oidc, …) | In production CI use |
+| [`@mat3ra/tede`](https://github.com/mat3ra/tede) | The test framework: Feature → Step → Widget/TAO → Browser → Driver layering; the Browser layer exists precisely so the driver (Cypress, Webdriver, Playwright) is swappable | Published, reused across projects |
+| `src/mcp-server/` | `StepCatalog` (scans step definitions — 514 steps), `FeatureGenerator` (LLM → Gherkin with validation against the catalog), `runner` (executes `.feature` via Cypress CLI), LLM providers (Ollama, Gemini on Vertex) | Working |
+| `src/mat3ra-agent-desktop/` | Electron shell: chat panel, embedded browser, `PlaywrightStepExecutor` over CDP, widget ports (`LoginPage`, `MaterialDesignerWidget`, …), step log, intent classification (chat vs automation) | Working locally |
+
+Three things the experiment proves:
+
+1. Natural language → **validated** Gherkin works: generation is constrained
+   to catalog steps and rejected otherwise.
+2. Steps are driver-portable: the desktop ported Cypress widgets to
+   Playwright twice ("reuse cy steps with playwright"), confirming TeDe's
+   Browser abstraction does its job.
+3. Execution currently needs a privileged shell (Electron + CDP). Closing
+   that gap — execution from a plain web page — is what this plan adds.
+
+## 3. Execution model: in-page, in-session
+
+Where should steps execute? The options:
+
+| Option | Verdict |
+| --- | --- |
+| **In-page runner** in the user's session | **Chosen.** The user watches every step in their own tab; the user's session is the credential — nothing is delegated; nothing to install. Cypress is the existence proof: it already automates this application in-page with synthetic events, and the whole suite passes. |
+| Server-side browser (Playwright) acting as the user | Rejected: requires session delegation to a server (credential custody, a new attack surface), invisible to the user, heavy to operate. |
+| Browser extension / CDP | Rejected for the widget: install friction. CDP remains the desktop app's mechanism. |
+| REST-API tools (the original Phase-5 sketch in the RAG plan) | Deferred, not rejected: robust for bulk/headless operations, but requires API-token custody at the service, bypasses the UI the user is trying to learn, and is not exercised by the UI test suite. Revisit after the UI-step path ships. |
+
+The TeDe fit: implement a **DOM driver** for TeDe's Browser layer — the
+third driver after Cypress and the desktop's Playwright. Widgets, TAOs¹ and
+step definitions stay unchanged; the driver queries the live document and
+dispatches events (with the known native-setter technique for React
+controlled inputs, as Cypress does).
+
+¹ TAOs are excluded from the agent surface entirely: they exist to seed test
+data through privileged paths and have no business running in production.
+The agent gets UI widgets only.
+
+## 4. Architecture
+
+```
+platform.mat3ra.com (user signed in via OIDC)
+│
+│  Platform bundle ships: action runner = TeDe DOM driver + step executor
+│  + step catalog (versioned with the app), exposed as window.Mat3raAgentRunner
+│
+└─ Ask AI widget (M8, service-served)
+     │  POST /chat (SSE; OIDC ID token; client-held history;
+     │             reports the runner's catalog version)
+     ▼
+   docs-agent service ── tools: search_docs | propose_actions
+     ▼                              (validated against the reported catalog)
+   Claude on Vertex
+```
+
+Components:
+
+1. **Step-catalog artifact.** Built in the platform repository's CI from the step definitions
+   (the MCP server's `StepCatalog` scan, made a build step): step name,
+   parameters, domain, description, and a **mutation classification** (§5).
+   Shipped inside the platform bundle and published for the service.
+2. **Runner in the platform bundle, widget from the service.** The runner
+   (DOM driver + executor + catalog) is platform code, versioned and deployed
+   with the application — selectors, steps, and app can never skew. The chat
+   widget stays service-served (M8) and talks to the runner through a small
+   `window` API. The widget without the runner degrades to chat-only; the
+   service validates plans against the catalog version the client reports.
+3. **Planning in the service.** A `propose_actions` tool: the model drafts
+   steps, the service validates them against the catalog (porting
+   `FeatureGenerator`'s validation), invalid plans bounce back for repair.
+   This is where the two workstreams converge: `search_docs` tells the agent
+   *what* the procedure is (tutorials), the catalog tells it *how* to perform
+   it (steps) — one grounded loop does both.
+4. **Client-executed action protocol** on the existing stateless `/chat`:
+   when the model calls `propose_actions`, the SSE stream ends with an
+   `action_request` event carrying the validated plan. The widget renders the
+   plan with mutating steps highlighted; the user confirms once per plan;
+   the runner executes step-by-step with a live log and a stop button; the
+   widget appends the structured results (per-step status, error, DOM
+   context on failure) as the tool result in the client-held history and
+   POSTs `/chat` again. The model then continues — explains, repairs the
+   plan, or finishes. No server session state, exactly as in M3.
+
+## 5. Safety model (input to the security review)
+
+- **Vocabulary allowlist.** Only catalog steps can be planned (validated
+  server-side) or executed (validated again by the runner). There is no
+  free-form "evaluate JavaScript" or "click arbitrary selector" step.
+- **Per-step classification**, stored in the catalog, human-reviewed:
+  `read` (navigate, open, list, assert) runs unprompted once a plan is
+  confirmed; `mutate` (create, edit, submit) requires the plan-level
+  confirmation and is highlighted; `destructive-or-billing` (delete, purge,
+  purchase, share outside the account) is **blocked in v1** — the agent
+  explains the manual procedure with documentation citations instead.
+- **Session boundary.** Everything runs as the signed-in user in their own
+  tab; the service holds no platform credentials and cannot act when the
+  user is absent. OIDC identity (M8.2) gates the capability: anonymous
+  docs.mat3ra.com traffic never sees action tools.
+- **Visible and interruptible.** Live step log in the widget, a stop button
+  between steps, and per-step timeouts.
+- **Prompt injection.** DOM-derived tool results (element text, entity
+  names) re-enter the model and are treated as data; the vocabulary
+  constraint bounds what a poisoned string can cause. Injection scenarios —
+  e.g. a material named "ignore previous instructions…" — are an explicit
+  security-review test case.
+- **Audit.** Plan, confirmation, and per-step outcomes logged per account
+  (extends decision D7).
+- **Rollout.** Internal accounts → feature-flagged beta → general; the
+  capability flag in service configuration is the kill switch.
+
+## 6. The test framework as the quality loop
+
+This is the reason to build actions on the test suite rather than beside it:
+
+1. **Coverage by construction.** Every step the agent can execute is
+   exercised by the E2E suite in the platform repository's CI. A step that starts failing in
+   CI is pulled from the published catalog, and the agent degrades to
+   instructions-with-citations for that capability instead of failing
+   mid-action.
+2. **Golden action set.** The action analog of the M2 golden questions:
+   natural-language request → expected Gherkin plan → replay through the
+   existing Cypress runner against a seeded environment in CI. Catches both
+   planning regressions (prompt/model changes) and execution regressions
+   (app changes).
+3. **Cross-driver parity.** The same `.feature` must pass under the Cypress
+   driver (CI) and the DOM driver (the widget runner, driven by Playwright
+   in CI as the harness). Parity failures mean the DOM driver lies about a
+   capability.
+4. **New capabilities are test-driven.** Adding an agent skill = writing the
+   step definitions, widgets, and tests first; the catalog regenerates; the
+   agent can now plan with it. No agent-side code changes — the test suite
+   is the agent's skill tree.
+5. **The desktop app stays** as the step-development harness (interactive
+   Playwright execution, step log) and a power-user tool. Optional later
+   convergence: its planner calls the docs-agent service instead of local
+   Gemini/Ollama, keeping one planning implementation.
+
+## 7. Staging
+
+Sequenced after M8.2 (OIDC identity at the service). Each stage shippable
+alone.
+
+| Stage | Scope | Where | Estimate |
+| --- | --- | --- | --- |
+| A1 | Catalog build step with classification; TeDe DOM driver MVP (navigate, open explorer, click widget control, fill field, assert visible) with cross-driver parity tests | platform repo, `tede` | 3–5 days |
+| A2 | `propose_actions` + validation in the service; `action_request` protocol; capability flag, OIDC-gated | service repo, widget | 2–3 days |
+| A3 | Widget action mode: plan preview, confirmation, live step log, stop; `read` steps first, then `mutate` | widget, platform repo (runner exposure) | 3–5 days |
+| A4 | Golden action set in the platform repository's CI; audit logging; security review; internal beta | platform repo, service | 2–3 days + review |
+
+## 8. Open decisions
+
+1. **First domains.** Recommendation: materials and workflows, read-heavy
+   steps first — they map directly onto the most-read tutorials.
+2. **Classification ownership.** Who reviews and signs off the per-step
+   `read`/`mutate`/`blocked` labels; CI should fail on unclassified steps.
+3. **DOM driver home.** Recommendation: inside `@mat3ra/tede` next to the
+   existing drivers, versioned with the steps that depend on it.
+4. **Desktop convergence** on the service planner: worth doing, not urgent.

--- a/plans/docs-agent-rag.md
+++ b/plans/docs-agent-rag.md
@@ -3,10 +3,16 @@
 Plan for an assistant that answers user questions from the content of this
 repository (docs.mat3ra.com), grounded with Retrieval-Augmented Generation (RAG).
 
-- **Status:** Phase 1 in progress — a working demo is committed in
-  [`scripts/rag/`](../scripts/rag/).
-- **Last updated:** 2026-07-28
-- **Companion plan:** [`docs-agent-web-app.md`](docs-agent-web-app.md) (browser delivery)
+- **Status:** Active — the strategy reference for retrieval and evaluation.
+  Of its content, Phase 0 (prototypes) is complete — a working demo is
+  committed in [`scripts/rag/`](../scripts/rag/) and since rebuilt in the
+  [`documentation-agent`](https://github.com/mat3ra/documentation-agent)
+  repository (D6) — while evaluation (§5) and
+  retrieval upgrades (§4.3) are still ahead. Phase numbering and live
+  progression: [implementation plan](docs-agent-implementation.md) §3.
+- **Last updated:** 2026-07-31
+- **Companion plan:** [`docs-agent-web-delivery.md`](docs-agent-web-delivery.md) (browser delivery)
+- **Implementation plan:** [`docs-agent-implementation.md`](docs-agent-implementation.md)
 
 ---
 
@@ -25,7 +31,7 @@ Claude on Vertex AI.
 | Contextual retrieval (chunk situating) | Not started |
 | `get_page` tool (fetch a whole page) | Not started |
 | Evaluation harness | Not started |
-| Any web interface | Not started — see the [web app plan](docs-agent-web-app.md) |
+| Any web interface | Not started — see the [web delivery plan](docs-agent-web-delivery.md) |
 
 Verified behaviour: asked how to import a material from a POSCAR file, the agent
 issued four searches (including section-filtered reformulations) and produced a
@@ -34,12 +40,17 @@ two-method answer citing `materials/actions/upload/` and
 
 ### What changed from the original proposal
 
-1. **Phase 0 was skipped.** The original plan proposed a "whole corpus in the
-   context window" baseline before building retrieval. Retrieval turned out to be
-   cheap enough to build directly, so the baseline was never needed. It remains
-   useful as a *quality ceiling* for evaluation (§5) and can still be run later.
-2. **The platform is Google Vertex AI, not the Claude API directly**, using
-   `claude-opus-4-6`. This constrains some of the original design — see §3.2.
+1. **The full-corpus baseline was skipped.** The original plan proposed a
+   "whole corpus in the context window" baseline before building retrieval.
+   Retrieval turned out to be cheap enough to build directly, so the baseline
+   was never needed. It remains useful as a *quality ceiling* for evaluation
+   (§5) and can still be run later.
+2. **The platform is Google Vertex AI, not the Claude API directly.** This
+   constrains some of the original design — see §3.2. The model is no longer
+   fixed: as of 2026-07-31 the agent runs behind a provider abstraction with
+   **Gemini as the default** (Claude on Vertex additionally requires Model
+   Garden enablement) and Claude selectable by configuration. Which one ships
+   is an evaluation question (§5), not a preference.
 3. **Retrieval is lexical (BM25), not vector-based.** This was a deliberate
    scope cut, not an oversight: it removes all index infrastructure from the
    demo while still exercising the full agent loop. Its limits are known and
@@ -69,8 +80,8 @@ User question
      │
      ▼
 ┌─────────────────────────────┐        ┌──────────────────────────┐
-│  Agent (scripts/rag/agent.py)│  tool  │  Retrieval               │
-│  claude-opus-4-6 on Vertex   │───────▶│  BM25 over doc chunks    │
+│  Agent (mat3ra_docs_agent)   │  tool  │  Retrieval               │
+│  Gemini or Claude on Vertex  │───────▶│  BM25 over doc chunks    │
 │  system prompt (cached)      │◀───────│  (→ hybrid, later)       │
 │  tool: search_docs           │ chunks └──────────────────────────┘
 └─────────────┬───────────────┘
@@ -88,8 +99,8 @@ Design decisions as implemented:
 
 | Decision | Choice | Rationale |
 | --- | --- | --- |
-| Model | `claude-opus-4-6` (Vertex) | Strong tool use and grounding |
-| Region | `us-east5` | Confirmed working for this project; `global` also valid |
+| Model | Gemini by default, Claude behind the same interface | Both do grounded tool use; Gemini needs no Model Garden step, so it unblocks work |
+| Region | Per provider: Gemini `global`, Claude `us-east5` | Model availability is region-specific — Gemini 3.x is not served from `us-east5` |
 | Loop | Hand-written | The SDK `tool_runner` helper is not available on `AnthropicVertex` (verified against SDK 0.116) |
 | Caching | `cache_control` on the system prompt | Stable prefix, re-read on every turn |
 | Tool-loop bound | 8 iterations per user turn | Prevents a runaway loop from billing indefinitely |
@@ -189,7 +200,7 @@ The index is currently rebuilt by hand (`python ingest.py`). The generated
 
 For production: rebuild on merge to `main` in CI, and version the artifact with
 the documentation commit it was built from, so an answer can always be traced to
-a documentation snapshot. See the [web app plan](docs-agent-web-app.md) for how
+a documentation snapshot. See the [web delivery plan](docs-agent-web-delivery.md) for how
 that artifact reaches the deployed service.
 
 ---
@@ -214,8 +225,8 @@ prompt parameters. It is the highest-leverage unbuilt piece of this plan.
 4. **Tuning levers**, iterated against the golden set: chunk size, top-k, fusion
    weights, reranking, the contextual-retrieval prompt, system prompt wording,
    and model tier.
-5. **Regression gate:** run the evaluation in CI when `scripts/rag/` or the
-   system prompt changes.
+5. **Regression gate:** run the evaluation in CI on every change to the
+   agent repository — retrieval, prompt, or model configuration.
 
 Note the Vertex constraint from §3.2: no Batch API, so evaluation runs are
 billed at standard rates.
@@ -224,14 +235,21 @@ billed at standard rates.
 
 ## 6. Roadmap
 
+The phase numbering is shared by all four plans; the
+[implementation plan](docs-agent-implementation.md) §3 maps each phase to
+concrete milestones.
+
 | Phase | Scope | State |
 | --- | --- | --- |
-| 0 | Full-corpus-in-context baseline | Skipped — optional, as an evaluation ceiling |
-| 1 | Ingestion, BM25 retrieval, agentic loop, CLI | **Done** |
-| 2 | Golden set + evaluation harness | Next — everything below is tuned against it |
-| 3 | Contextual retrieval, embeddings, hybrid search, `get_page` | Planned (§4.3) |
-| 4 | Web delivery | See [`docs-agent-web-app.md`](docs-agent-web-app.md) |
-| 5 | Platform actions — tools generated from `rest-api/` docs, authenticated per user | Later; needs its own security review |
+| 0 | Prototypes: this repository's demo (ingestion, BM25 retrieval, agentic loop, CLI) and the platform repository's desktop automation experiment | **Done** |
+| 1 | Foundations: shared core package, golden set + evaluation harness | In progress — the package is done and now lives in the `documentation-agent` repository; the harness is next |
+| 2 | Docs launch: service, widget, deployment, hardening | Planned — see the [web delivery plan](docs-agent-web-delivery.md) |
+| 3 | Retrieval quality: contextual retrieval, embeddings, hybrid search, `get_page` (§4.3) | Planned, evaluation-gated |
+| 4 | Platform embed: the same widget inside platform.mat3ra.com | Planned |
+| 5 | Platform actions — the agent performs documented procedures in the user's session | Proposed in [`docs-agent-platform-actions.md`](docs-agent-platform-actions.md) (UI steps via the test framework; REST-API tools deferred); needs its own security review |
+
+The full-corpus-in-context baseline (the corpus fits a 1M-token window)
+remains available outside the numbering as an evaluation ceiling (§5).
 
 ---
 
@@ -259,7 +277,7 @@ current rates should be confirmed against Vertex pricing before committing.
 - **Stale answers after documentation edits** — CI re-indexing on merge (§4.4).
 - **Runaway tool loops** — bounded at 8 iterations per turn.
 - **Prompt injection and abuse** — relevant once the agent is exposed publicly;
-  covered in the [web app plan](docs-agent-web-app.md).
+  covered in the [web delivery plan](docs-agent-web-delivery.md).
 - **Query privacy** — user questions may contain proprietary research context. A
   logging and retention policy is required before any public deployment.
 - **Machine-translated pages** — `lang/ja/` is never indexed; multilingual

--- a/plans/docs-agent-web-delivery.md
+++ b/plans/docs-agent-web-delivery.md
@@ -1,11 +1,18 @@
-# Documentation Agent — Web App Plan
+# Documentation Agent — Web Delivery Plan
 
-Plan for turning the working command-line agent
-([`scripts/rag/agent.py`](../scripts/rag/agent.py)) into a browser-based chat.
+Plan for turning the working command-line agent (the `mat3ra_docs_agent`
+package in the
+[`documentation-agent`](https://github.com/mat3ra/documentation-agent)
+repository) into a browser-based chat.
+"Web delivery" here means shipping the documentation agent to browsers — not
+to be confused with the platform application, whose repository is named
+`web-app`.
 
-- **Status:** proposal — nothing built yet.
-- **Last updated:** 2026-07-28
+- **Status:** Active — the architecture reference for Phase 2 (docs launch);
+  nothing built yet.
+- **Last updated:** 2026-07-31
 - **Companion plan:** [`docs-agent-rag.md`](docs-agent-rag.md) (agent and retrieval strategy)
+- **Implementation plan:** [`docs-agent-implementation.md`](docs-agent-implementation.md)
 
 ---
 
@@ -49,10 +56,11 @@ retrieval plan's own schedule.
 
 ## 2. Where the service should live
 
-### 2.1. Not inside the platform web application
+### 2.1. Not inside the platform application
 
-The platform user interface is a large Meteor application. It is the wrong home
-for a public documentation assistant:
+The platform (platform.mat3ra.com) is a large Meteor application maintained
+in the `web-app` repository. It is the wrong home for a public documentation
+assistant:
 
 | | Standalone service | Inside the platform application |
 | --- | --- | --- |
@@ -129,17 +137,21 @@ launcher appears on every documentation page.
 The documentation repository is **public**. The service's operational
 configuration should not be. Split by what each part is coupled to:
 
+> **Revised 2026-07-31 (decision D6).** The split below was reconsidered: the
+> agent core now lives with the service rather than here. The reasoning about
+> what must stay private is unchanged; only the boundary moved.
+
 | Concern | Repository | Reason |
 | --- | --- | --- |
-| Corpus, ingestion, retrieval core, prompt | **This (public) repository**, in `scripts/rag/` | Coupled to the documentation; contains nothing sensitive; stays a runnable reference |
-| Service: HTTP layer, container, deployment manifests, access policy, rate limiting | **Separate private repository** | Coupled to infrastructure; matches the existing convention of one repository per service, aggregated into the platform stack as a submodule |
-| Built index | **Published artifact**, not committed | Generated content; versioned by the documentation commit it was built from |
+| Corpus (the Markdown itself) | **This (public) repository** | It is the documentation |
+| Ingestion, retrieval core, prompt, agent loop, HTTP service, container, deployment | **`documentation-agent` (private)** | One repository owns all agent code, so there is no cross-repository package version to keep in step; ingestion reads a documentation checkout at a pinned commit |
+| Built index | **Baked into the service image**, not committed | Generated content; versioned by the documentation commit it was built from |
 
-To avoid duplicating the retrieval core across two repositories, keep the
-dependency one-way: this repository publishes a small installable package that
-the private service depends on. That is preferable to the service vendoring the
-documentation repository, which would drag a large Git LFS history into a
-service image.
+The rejected alternative was a one-way package dependency (this repository
+publishing an installable core that the service imports). It works, but it
+splits one codebase across two release cadences for no gain now that the
+service is the only consumer. The service checks out the documentation at a
+specific SHA rather than vendoring it, so no Git LFS history enters the image.
 
 ---
 
@@ -213,14 +225,18 @@ for a demonstration; weaker as a foundation.
 
 ## 7. Roadmap
 
-| Step | Scope | Estimate |
+Milestone identifiers and phase numbering follow the
+[implementation plan](docs-agent-implementation.md) §3, which supersedes
+this table for sequencing.
+
+| Milestone (phase) | Scope | Estimate |
 | --- | --- | --- |
-| W0 | Extract `rag_core.py`; command-line wrapper imports it | 0.5 day |
-| W1 | FastAPI `/chat` with streaming and the tool loop; CORS; local run | 2–4 days |
-| W2 | Embeddable widget in the MkDocs theme; streamed Markdown and citations | 3–5 days |
-| W3 | Container, deployment pipeline, service-account auth, rate limiting, spend alerts | 2–3 days |
-| W4 | Hybrid retrieval behind the same interface; evaluation gate; latency tuning | 1–2 weeks |
-| Later | In-platform surface; authenticated action tools (separate security review) | As prioritised |
+| M1 (Phase 1) | Extract the shared core package; command-line wrapper imports it | 0.5–1 day |
+| M3 (Phase 2) | FastAPI `/chat` with streaming and the tool loop; CORS; local run | 2–4 days |
+| M4 (Phase 2) | Embeddable widget in the MkDocs theme; streamed Markdown and citations | 3–5 days |
+| M5 (Phase 2) | Container, deployment pipeline, service-account auth, rate limiting, spend alerts | 2–3 days |
+| M7 (Phase 3) | Hybrid retrieval behind the same interface; evaluation gate; latency tuning | 1–2 weeks |
+| Phases 4–5 | In-platform surface (M8); platform actions ([`docs-agent-platform-actions.md`](docs-agent-platform-actions.md), separate security review) | As prioritised |
 
 ## 8. Cost
 

--- a/scripts/rag/README.md
+++ b/scripts/rag/README.md
@@ -1,8 +1,17 @@
-# Docs RAG Agent — Minimal Demo
+# Docs RAG Agent — Minimal Demo (superseded)
+
+> **Superseded as of 2026-07-31.** This Phase-0 prototype has been rebuilt as
+> an installable package with a provider abstraction, tests, and CI in the
+> [`documentation-agent`](https://github.com/mat3ra/documentation-agent)
+> repository (decision D6 in
+> [`plans/docs-agent-implementation.md`](../../plans/docs-agent-implementation.md)).
+> It is kept here only until that work is pushed, then removed. New work goes
+> in the new repository.
+
 
 A grounded question-answering agent over the Mat3ra documentation. It retrieves
 relevant doc sections with BM25 and answers using **Claude Opus 4.6 on Google
-Vertex AI**, citing `docs.mat3ra.com` URLs. This is the Phase-1 minimal build
+Vertex AI**, citing `docs.mat3ra.com` URLs. This is the Phase-0 prototype
 from [`plans/docs-agent-rag.md`](../../plans/docs-agent-rag.md).
 
 ## What it does

--- a/tests/widget/README.md
+++ b/tests/widget/README.md
@@ -1,0 +1,54 @@
+# Ask AI widget — browser tests
+
+Playwright tests for the documentation assistant widget
+(`extra/js/docs-agent.js`).
+
+```bash
+cd tests/widget
+npm install
+npx playwright install chromium
+npm test
+```
+
+## What is real and what is faked
+
+The **widget is real** — the tests load the file the documentation site ships,
+through a fixture page that mounts it the way the site does.
+
+The **agent service is faked** at the network boundary (`mock-agent.js`). A test
+that called a language model would be neither deterministic nor free, and what
+is under test is the widget's behaviour, not the model's; the service is covered
+by its own suite in the `documentation-agent` repository.
+
+`server.js` synthesises a page for *every* path. Answers cite canonical
+`docs.mat3ra.com` URLs which the widget rewrites onto the origin being read, so
+following a citation has to land on a page that mounts the widget again — that
+navigation is the thing several tests are about.
+
+Both mounting styles are covered, because they differ: `?automount=1` loads the
+page the way the documentation site does, where the widget only appears once the
+service passes a health check; the default mounts explicitly, the way the
+platform application will.
+
+## What is covered
+
+- **Mounting** — the launcher appears when the service is healthy, and a
+  documentation page is left untouched when it is not.
+- **Rendering** — Markdown becomes structure; searches are announced while they
+  run.
+- **Links** — cited URLs are clickable, known product terms link to the page
+  that defines them, unknown emphasis stays plain, links open in the same tab
+  and are coloured, and citations stay on the build being read.
+- **Safety** — markup in an answer is displayed rather than executed, and a
+  non-https link never becomes clickable.
+- **The conversation** — it survives a reload and a followed citation, the panel
+  reopens only if it was open, "New chat" ends it, a week-old conversation is
+  discarded, and the widget still works where storage is unavailable.
+
+## Keeping the suite honest
+
+A green suite means nothing until it has been seen to fail. Both regressions
+these tests were written for have been reintroduced deliberately and confirmed
+to fail the run: restoring `target="_blank"` fails *links open in the same tab*,
+and skipping session restoration fails *it is restored after a reload*. Do the
+same when adding a test — break the behaviour first, watch it go red.

--- a/tests/widget/mock-agent.js
+++ b/tests/widget/mock-agent.js
@@ -1,0 +1,59 @@
+/**
+ * The agent service, faked at the network boundary.
+ *
+ * The widget is tested against canned responses rather than the deployed
+ * service: a test that calls a language model is neither deterministic nor
+ * free, and what is under test here is the widget's behaviour, not the
+ * model's. The service's own behaviour is covered by its Python suite.
+ */
+
+const GLOSSARY = {
+  "materials bank": "https://docs.mat3ra.com/materials/bank/",
+  "materials designer": "https://docs.mat3ra.com/materials-designer/overview/",
+};
+
+/** An answer body, as the service streams it. */
+function sse(events) {
+  return events.map(([name, data]) => `event: ${name}\ndata: ${JSON.stringify(data)}\n\n`).join("");
+}
+
+const DEFAULT_ANSWER = sse([
+  ["status", { message: "Searching the documentation", query: "materials bank" }],
+  ["text", { text: "## Importing\n\nUse the **Materials Bank** or the " }],
+  ["text", { text: "**Materials Designer**. Bold **Second unit (NSCF):** is not a term.\n\n" }],
+  ["text", { text: "1. Open the bank\n2. Copy the material\n\n```bash\nqstat\n```\n\n" }],
+  ["text", { text: "Sources:\n\n- https://docs.mat3ra.com/materials/bank/\n" }],
+  ["sources", { urls: ["https://docs.mat3ra.com/materials/bank/"] }],
+  ["done", {}],
+]);
+
+/**
+ * Route the widget's calls to `https://agent.test`.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {{healthy?: boolean, answer?: string}} options
+ */
+async function mockAgent(page, options = {}) {
+  const healthy = options.healthy !== false;
+  const answer = options.answer || DEFAULT_ANSWER;
+
+  await page.route("https://agent.test/health", (route) =>
+    healthy
+      ? route.fulfill({ status: 200, contentType: "application/json", body: '{"status":"ok"}' })
+      : route.abort()
+  );
+
+  await page.route("https://agent.test/glossary", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ terms: GLOSSARY }),
+    })
+  );
+
+  await page.route("https://agent.test/chat", (route) =>
+    route.fulfill({ status: 200, contentType: "text/event-stream", body: answer })
+  );
+}
+
+module.exports = { mockAgent, sse, GLOSSARY };

--- a/tests/widget/package-lock.json
+++ b/tests/widget/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "docs-agent-widget-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "docs-agent-widget-tests",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/tests/widget/package.json
+++ b/tests/widget/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "docs-agent-widget-tests",
+  "private": true,
+  "description": "Browser tests for the Ask AI documentation widget.",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0"
+  }
+}

--- a/tests/widget/playwright.config.js
+++ b/tests/widget/playwright.config.js
@@ -1,0 +1,25 @@
+const { defineConfig, devices } = require("@playwright/test");
+
+const PORT = Number(process.env.PORT || 4173);
+const baseURL = `http://localhost:${PORT}`;
+
+module.exports = defineConfig({
+  testDir: __dirname,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"], baseURL } },
+  ],
+  webServer: {
+    command: `node ${__dirname}/server.js`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    env: { PORT: String(PORT) },
+  },
+});

--- a/tests/widget/server.js
+++ b/tests/widget/server.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Static server for the widget tests.
+ *
+ * Serves the real widget assets from the repository, and synthesises a stub
+ * documentation page for every other path. That second part matters: answers
+ * cite canonical docs.mat3ra.com URLs which the widget rewrites onto the origin
+ * being read, so the test needs every such path to resolve to a page that
+ * mounts the widget again — that is precisely the navigation being tested.
+ */
+
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const PORT = Number(process.env.PORT || 4173);
+
+const TYPES = { ".js": "text/javascript", ".css": "text/css" };
+
+/**
+ * Two ways to mount, because the widget supports two and they behave
+ * differently: the documentation site lets the script mount itself only once
+ * the service passes a health check, while the platform will mount it
+ * explicitly. `?automount=1` exercises the first, the default the second.
+ */
+const PAGE = (pathname, autoMount) => `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Docs fixture ${pathname}</title>
+  <link rel="stylesheet" href="/extra/css/docs-agent.css">
+</head>
+<body>
+  <h1>Documentation fixture</h1>
+  <p id="path">${pathname}</p>
+  <div id="agent"></div>
+${
+  autoMount
+    ? `  <script>localStorage.setItem("docsAgentEndpoint", "https://agent.test");</script>
+  <script src="/extra/js/docs-agent.js"></script>`
+    : `  <script>window.DOCS_AGENT_NO_AUTOMOUNT = true;</script>
+  <script src="/extra/js/docs-agent.js"></script>
+  <script>
+    DocsAgent.mount(document.getElementById("agent"), {
+      endpoint: "https://agent.test",
+      docsOrigin: location.origin,
+    });
+  </script>`
+}
+</body>
+</html>`;
+
+const server = http.createServer((request, response) => {
+  const url = new URL(request.url, "http://localhost");
+  const pathname = url.pathname;
+
+  if (pathname.startsWith("/extra/")) {
+    const file = path.join(REPO_ROOT, pathname);
+    if (fs.existsSync(file)) {
+      response.writeHead(200, { "Content-Type": TYPES[path.extname(file)] || "text/plain" });
+      response.end(fs.readFileSync(file));
+      return;
+    }
+    response.writeHead(404).end("not found");
+    return;
+  }
+
+  response.writeHead(200, { "Content-Type": "text/html" });
+  response.end(PAGE(pathname, url.searchParams.get("automount") === "1"));
+});
+
+server.listen(PORT, () => console.log(`fixture server on http://localhost:${PORT}`));

--- a/tests/widget/widget.spec.js
+++ b/tests/widget/widget.spec.js
@@ -1,0 +1,220 @@
+const { test, expect } = require("@playwright/test");
+const { mockAgent, sse } = require("./mock-agent");
+
+const LAUNCHER = ".docs-agent-launcher";
+const PANEL = ".docs-agent-panel";
+const MESSAGES = ".docs-agent-message";
+
+async function ask(page, question = "How do I import a material?", expected = "Importing") {
+  await page.click(LAUNCHER);
+  await page.fill(".docs-agent-form input", question);
+  await page.click(".docs-agent-form button[type=submit]");
+  await expect(page.locator(MESSAGES).last()).toContainText(expected);
+}
+
+test.describe("mounting", () => {
+  test("the launcher appears once the service answers its health check", async ({ page }) => {
+    await mockAgent(page);
+    await page.goto("/?automount=1");
+    await expect(page.locator(LAUNCHER)).toBeVisible();
+  });
+
+  test("a documentation page is untouched when the service is unreachable", async ({ page }) => {
+    // The widget must never leave a control that leads nowhere, and must never
+    // break the page it is embedded in.
+    await mockAgent(page, { healthy: false });
+    await page.goto("/?automount=1");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.locator(LAUNCHER)).toHaveCount(0);
+    await expect(page.locator("h1")).toContainText("Documentation fixture");
+  });
+});
+
+test.describe("answers", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAgent(page);
+    await page.goto("/");
+  });
+
+  test("markdown is rendered as structure, not as text", async ({ page }) => {
+    await ask(page);
+    const answer = page.locator(MESSAGES).last();
+
+    await expect(answer.locator("h4, h3")).toHaveCount(1);
+    await expect(answer.locator("ol li")).toHaveCount(2);
+    await expect(answer.locator("pre code")).toContainText("qstat");
+  });
+
+  test("a search in progress is announced", async ({ page }) => {
+    let release;
+    const held = new Promise((resolve) => (release = resolve));
+    await page.route("https://agent.test/chat", async (route) => {
+      await held;
+      route.fulfill({ status: 200, contentType: "text/event-stream", body: sse([["done", {}]]) });
+    });
+
+    await page.click(LAUNCHER);
+    await page.fill(".docs-agent-form input", "anything");
+    await page.click(".docs-agent-form button[type=submit]");
+    await expect(page.locator(".docs-agent-status")).toBeVisible();
+    release();
+  });
+
+  test("known product terms link to the page that defines them", async ({ page }) => {
+    await ask(page);
+    const term = page.locator("a.docs-agent-term", { hasText: "Materials Bank" });
+    await expect(term).toHaveAttribute("href", /\/materials\/bank\/$/);
+  });
+
+  test("emphasis the glossary does not know stays plain", async ({ page }) => {
+    // Over-linking is the failure mode here: a link to the wrong page looks
+    // deliberate, so anything unrecognised must remain bold text.
+    await ask(page);
+    const answer = page.locator(MESSAGES).last();
+    const plain = answer.locator("strong", { hasText: "Second unit (NSCF):" });
+
+    await expect(plain).toHaveCount(1);
+    await expect(plain.locator("a")).toHaveCount(0);
+  });
+
+  test("cited URLs are clickable", async ({ page }) => {
+    await ask(page);
+    const links = page.locator(`${MESSAGES} a`);
+    expect(await links.count()).toBeGreaterThan(0);
+  });
+
+  test("links open in the same tab and look like links", async ({ page }) => {
+    await ask(page);
+    const link = page.locator(`${MESSAGES} a`).first();
+
+    await expect(link).not.toHaveAttribute("target", "_blank");
+    const colour = await link.evaluate((node) => getComputedStyle(node).color);
+    expect(colour).not.toBe("rgb(0, 0, 0)");
+  });
+
+  test("citations stay on the documentation build being read", async ({ page }, testInfo) => {
+    // The corpus stores canonical production URLs. On a preview or a local
+    // build, following one verbatim would leave the site — and the stored
+    // conversation, which is per-origin, behind with it.
+    await ask(page);
+    const hrefs = await page.locator(`${MESSAGES} a`).evaluateAll((nodes) =>
+      nodes.map((node) => node.href)
+    );
+
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) {
+      expect(href.startsWith(testInfo.project.use.baseURL)).toBeTruthy();
+    }
+  });
+});
+
+test.describe("safety", () => {
+  test("markup in an answer is shown, never executed", async ({ page }) => {
+    const hostile = sse([
+      [
+        "text",
+        {
+          text:
+            "Try <img src=x onerror=\"window.__pwned=1\"> and " +
+            "<script>window.__pwned=1<\/script> plus [click](javascript:window.__pwned=1).",
+        },
+      ],
+      ["done", {}],
+    ]);
+    await mockAgent(page, { answer: hostile });
+    await page.goto("/");
+    await ask(page, "anything", "onerror");
+
+    expect(await page.evaluate(() => window.__pwned)).toBeUndefined();
+    // The markup arrives as text rather than as nodes.
+    await expect(page.locator(`${MESSAGES} img`)).toHaveCount(0);
+    await expect(page.locator(MESSAGES).last()).toContainText("onerror");
+  });
+
+  test("a non-https link is not clickable", async ({ page }) => {
+    const hostile = sse([
+      ["text", { text: "See [the docs](javascript:alert(1)) for details." }],
+      ["done", {}],
+    ]);
+    await mockAgent(page, { answer: hostile });
+    await page.goto("/");
+    await ask(page, "anything", "javascript:alert(1)");
+
+    await expect(page.locator(`${MESSAGES} a`)).toHaveCount(0);
+    await expect(page.locator(MESSAGES).last()).toContainText("javascript:alert(1)");
+  });
+});
+
+test.describe("the conversation survives navigation", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAgent(page);
+    await page.goto("/");
+  });
+
+  test("it is restored after a reload, with the panel still open", async ({ page }) => {
+    await ask(page, "Where is the bank?");
+    await page.reload();
+
+    await expect(page.locator(PANEL)).toBeVisible();
+    await expect(page.locator(MESSAGES)).toHaveCount(2);
+    await expect(page.locator(MESSAGES).first()).toContainText("Where is the bank?");
+  });
+
+  test("following a citation keeps the exchange that produced it", async ({ page }) => {
+    // The behaviour the whole session-storage feature exists for.
+    await ask(page, "Where is the bank?");
+    await page.locator(`${MESSAGES} a`).first().click();
+    await page.waitForLoadState("load");
+
+    expect(new URL(page.url()).pathname).toBe("/materials/bank/");
+    await expect(page.locator(PANEL)).toBeVisible();
+    await expect(page.locator(MESSAGES).first()).toContainText("Where is the bank?");
+  });
+
+  test("a closed panel stays closed across pages", async ({ page }) => {
+    await ask(page);
+    await page.click(".docs-agent-close");
+    await page.reload();
+
+    await expect(page.locator(LAUNCHER)).toBeVisible();
+    await expect(page.locator(PANEL)).toBeHidden();
+  });
+
+  test("New chat ends it", async ({ page }) => {
+    await ask(page);
+    await page.click(".docs-agent-clear");
+
+    await expect(page.locator(MESSAGES)).toHaveCount(1); // the greeting
+    await page.reload();
+    await expect(page.locator(MESSAGES)).toHaveCount(1);
+  });
+
+  test("a stale conversation is discarded rather than resurrected", async ({ page }) => {
+    await ask(page);
+    await page.evaluate(() => {
+      const stored = JSON.parse(localStorage.getItem("docsAgentSession"));
+      stored.updated = Date.now() - 8 * 24 * 60 * 60 * 1000; // older than the week-long limit
+      localStorage.setItem("docsAgentSession", JSON.stringify(stored));
+    });
+    await page.reload();
+
+    await expect(page.locator(MESSAGES)).toHaveCount(1);
+    expect(await page.evaluate(() => localStorage.getItem("docsAgentSession"))).toBeNull();
+  });
+
+  test("the widget still works when storage is unavailable", async ({ page, context }) => {
+    // Private browsing and hardened settings can make localStorage throw.
+    await context.addInitScript(() => {
+      Object.defineProperty(window, "localStorage", {
+        get() {
+          throw new Error("storage disabled");
+        },
+      });
+    });
+    await page.goto("/");
+    await ask(page);
+
+    await expect(page.locator(MESSAGES).last()).toContainText("Importing");
+  });
+});


### PR DESCRIPTION
Part of [SOF-7992](https://mat3ra.atlassian.net/browse/SOF-7992). Plans + the **Ask AI widget (M4)**.

Stacked on `feat/agent-rag` (#389), which merges first.

## The widget (M4)

A launcher on every page opens a chat that streams grounded answers from the agent service, with the pages it used as links.

Wired **once** in `mkdocs-base.yml`. Every site config inherits from it and none override the asset lists, so this reaches all **eight** builds without touching them individually. (Note the site count has grown past the four in `AGENTS.md`.)

**Framework-free module** — `DocsAgent.mount(element, options)` — so the platform application can host the same code in its own shell rather than growing a second implementation. It assumes nothing about MkDocs; the docs site is just its first caller.

### On rendering model output safely

The plan called for vendoring `marked` + DOMPurify. I did neither: this builds DOM nodes and sets `textContent`, never `innerHTML`, for anything the model or corpus produced. Injection becomes *structurally impossible* rather than filtered, and the widget ships with zero dependencies. Links are only made clickable when they're `https`, so a poisoned URL can't become a trap.

The cost is a small Markdown renderer covering the subset the agent emits (headings, lists, fenced code, inline code, bold, links) — worth it against a parser-plus-sanitiser pair to keep patched.

### It must never break a documentation page

The launcher appears only once the service answers its health check, and a failed request degrades to one sentence pointing at the docs search box. Verified: with the endpoint pointed at a dead port, no launcher, no host element, page renders normally.

### One thing the browser caught

The widget originally appended a "Pages used" list under every answer — which duplicated the answer's own **Sources:** section *and* listed pages that were retrieved but never cited (`index-dev/`, an unrelated auth page). Those two lists aren't the same thing: the answer cites what the model used; the event carries everything retrieval returned. The widget now shows them only when the answer didn't cite its own, labelled "Pages searched".

Verified in a browser against the running service: a streamed multi-search answer with headings, a code block and working citation links; the degraded path; and the panel at phone width.

## Plans

| Document | Scope |
| --- | --- |
| `docs-agent-implementation.md` | Execution plan: phases 0–5, milestones M1–M8, decision register, progression tracker |
| `docs-agent-platform-actions.md` | Phase 5: the agent executing actions in the user's platform session |

Naming is unified — "the platform" is platform.mat3ra.com (repository `web-app`) — and `docs-agent-web-app.md` is renamed to `docs-agent-web-delivery.md`, which described browser delivery of the *documentation* agent and read as though it were about the platform repository.

The plans now carry measured results rather than intentions: the BM25 baseline, the D8 launch thresholds set from it, and what the evaluation harness found.

## Notes

Internal planning documents only — the MkDocs builds read `lang/en/docs/`, so nothing in `plans/` reaches docs.mat3ra.com. `.gitignore` adds `reference/`, a local clone of the service repository.

Link check: the 7 reported breaks are pre-existing cross-site links (`/guide/`, `/reference/`, …) absent because only the main site was built locally, not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SOF-7992]: https://mat3ra.atlassian.net/browse/SOF-7992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ