### PR TITLE
SOF-8014: tutorial for twisted MoS2 bilayer band structure

### DIFF
--- a/lang/en/docs/tutorials/materials/specific/defect-point-substitution-graphene-simulation.md
+++ b/lang/en/docs/tutorials/materials/specific/defect-point-substitution-graphene-simulation.md
@@ -85,7 +85,7 @@ In production mode, the structure is relaxed before the band structure calculati
 Navigate to the API examples repository and open the band structure calculation notebook:
 
 ```
-other/materials_designer/specific_examples/defect_point_substitution_graphene_simulation.ipynb
+other/materials_designer/specific_examples/defect_point_substitution_graphene_SIMULATION.ipynb
 ```
 
 ### 5.2. Configure parameters
@@ -225,7 +225,7 @@ The following JupyterLite notebook demonstrates the workflow for calculating the
 
 {% with origin_url=config.extra.jupyterlite.origin_url_lab %}
 {% with notebooks_path_root=config.extra.jupyterlite.notebooks_path_root %}
-{% with notebook_name='specific_examples/defect_point_substitution_graphene_simulation.ipynb' %}
+{% with notebook_name='specific_examples/defect_point_substitution_graphene_SIMULATION.ipynb' %}
 {% include 'jupyterlite_embed.html' %}
 {% endwith %}
 {% endwith %}

--- a/lang/en/docs/tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
+++ b/lang/en/docs/tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
@@ -1,0 +1,279 @@
+---
+tags:
+  - 2d-materials
+  - layers
+  - bilayer
+  - twisted
+  - commensurate
+  - molybdenum
+  - disulfide
+  - band-structure
+  - band-gap
+  - interlayer-coupling
+  - C-2D-INT-C
+
+hide:
+  - tags
+# YAML header
+render_macros: true
+---
+
+# Twisted Bilayer MoS2 Band Structure
+
+## 1. Introduction
+
+This tutorial calculates the electronic band structure and the band gaps of the twisted bilayer
+molybdenum disulfide (MoS2) structures created in the
+[structure creation tutorial](interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md),
+reproducing the electronic-structure result of the following manuscript.
+
+!!!note "Manuscript"
+    **Kaihui Liu, Liming Zhang, Ting Cao, Chenhao Jin, Diana Qiu, Qin Zhou, Alex Zettl, Peidong Yang, Steve G. Louie & Feng Wang**,
+    "Evolution of interlayer coupling in twisted molybdenum disulfide bilayers" Nature Communications volume 5, Article number: 4966 (2014)
+    [DOI: 10.1038/ncomms5966](https://doi.org/10.1038/ncomms5966) [@Liu2014]
+
+![Twisted Bilayer Molybdenum Disulfide](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/MoS2-twisted-bilayers.png "Twisted Bilayer Molybdenum Disulfide")
+
+### 1.1. What the manuscript found
+
+A MoS2 bilayer has an indirect bandgap, between a valence maximum at Γ and a conduction minimum at
+or near K. Both of those states are built from orbitals that stick out of the layer, so the
+size of the indirect gap measures how strongly the two layers are coupled; the K-valley states are
+confined within a layer and barely notice it.
+
+The manuscript's result is that this coupling is set by the interlayer **distance** and nothing
+else:
+
+* registered AA and AB stacking lets the two layers sit close together, and the indirect gap is
+  markedly smaller there;
+* every intermediate twist angle forces them apart by roughly the same amount — the sulfur atoms of
+  the two layers can no longer interleave — and every twisted configuration lands on the same,
+  larger indirect gap;
+* the K-valley direct gap moves by around 0.02 eV across the entire range;
+* horizontal alignment plays no part beyond setting the distance. Two bilayers at the same
+  interlayer distance have the same indirect gap whether they are twisted or registered.
+
+So the mechanism is steric rather than electronic: twisting changes the gap by changing how far
+apart the layers can sit.
+
+### 1.2. Theory and experiment are different numbers
+
+The manuscript reports photoluminescence peaks as well as calculated gaps, and these are not the
+same quantity. Photoluminescence measures optical transition energies, which include the binding
+energy of the exciton; a DFT calculation produces Kohn-Sham eigenvalue differences, which do not.
+The manuscript makes the point itself: the Kohn-Sham bandgaps should not be compared directly with
+the measured optical bandgaps, but the trend with twist angle should be correct.
+
+This tutorial reproduces the trend, not the photoluminescence peaks.
+
+
+## 2. Prerequisites
+
+Run the
+[structure creation tutorial](interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md)
+first. Its notebook saves each structure it builds into the `uploads` folder under a name such as
+`MoS2 bilayer 21.8deg d6.5`, and this notebook loads them back by exactly those names. A name that
+does not resolve stops the notebook rather than silently substituting a different material.
+
+
+## 3. What is calculated
+
+One job per structure, all with the same settings, so the results can be compared with each other.
+The structure notebook builds the manuscript's configurations:
+
+| structure | twist | d(Mo–Mo) | atoms |
+|---|---|---|---|
+| `MoS2 bilayer 21.8deg d6.5` | 21.8° | 6.5 Å | 42 |
+| `MoS2 bilayer AB1 d6.1` | 60° | 6.1 Å | 6 |
+| `MoS2 bilayer AB1 d6.5` | 60° | 6.5 Å | 6 |
+| `MoS2 bilayer AA3 d6.8` | 0° | 6.8 Å | 6 |
+| `MoS2 bilayer 13.2deg d6.5` | 13.2° | 6.5 Å | 114 |
+| `MoS2 bilayer 38.2deg d6.5` | 38.2° | 6.5 Å | 42 |
+| `MoS2 bilayer 46.8deg d6.5` | 46.8° | 6.5 Å | 114 |
+
+`MoS2 bilayer AB1 d6.5` is not one of the manuscript's own configurations — it is the registered
+stacking held at the twisted structures' interlayer distance, which separates the effect of the
+distance from the effect of the horizontal alignment.
+
+The simulation notebook computes the first entry by default; uncomment the others to add them. The
+114-atom cells are considerably more expensive than the rest.
+
+### 3.1. Interlayer distances are inputs here, not outputs
+
+The distances above are the manuscript's Table S1 LDA values, which are the *relaxed results* of its
+own calculations. This tutorial takes them as given and does not relax the structures.
+
+They are also quoted as the averaged **Mo–Mo** separation, while the structure builder takes the gap
+between the facing sulfur planes. The two differ by one monolayer's thickness, about 3.14 Å. The
+structure notebook measures that thickness on the slab it has just built, subtracts it, and prints
+the resulting Mo–Mo separation of the finished structure next to the value it was aiming for — worth
+reading, because passing an interlayer distance through in the wrong convention produces a structure
+that builds, runs and plots perfectly well with the interlayer coupling removed.
+
+### 3.2. Which registry a 0° or 60° stack comes out as
+
+Registered stacking is not a single structure. The manuscript distinguishes sulfur over molybdenum
+(AA1, AB1), sulfur over the centre of a hexagon (AA2, AB2) and sulfur over sulfur (AA3, AB3), and
+Table S1 gives each a different interlayer distance — 6.1 Å, 6.2 Å and 6.8 Å respectively, the
+eclipsed S-over-S stacking being pushed furthest apart.
+
+The structure builder has no registry parameter: it returns whatever the commensurate lattice search
+produces. The structure notebook therefore classifies each registered stack it builds from the
+in-plane offset between the facing sulfur planes and prints the answer. With the current builder, 0°
+produces AA3 and 60° produces AB1, which is why the 60° structure is the registered member of the
+comparison — it is the compact stacking the manuscript's headline sentence is about.
+
+
+## 4. Calculation parameters
+
+The manuscript used DFT in the local density approximation with norm-conserving pseudopotentials, a
+plane-wave cutoff of 140 Ry, 20 Å between periodic images along the out-of-plane direction, and no
+spin-orbit coupling.
+
+| | this tutorial | manuscript |
+|---|---|---|
+| Functional | LDA (`pz`) | LDA |
+| Pseudopotentials | ultrasoft (GBRV) | norm-conserving |
+| Wavefunction cutoff | 40 Ry, density 320 Ry | 140 Ry |
+| Vacuum | 20 Å region, ≈ 26 Å of vacuum in a ≈ 33 Å cell | 20 Å total cell |
+| Spin-orbit coupling | off | off |
+| Spin polarization | off | not applicable |
+| Geometry | fixed at Table S1 distances | relaxed |
+
+The pseudopotentials are the one real divergence, and it is forced: the platform carries no
+norm-conserving set for Mo or S under LDA, so the closest available match is the ultrasoft GBRV set
+at the same functional. Keeping the functional is what matters here — LDA is what binds this
+bilayer, and PBE without a dispersion correction does not — while the pseudopotential family mostly
+shifts the absolute gaps. Ultrasoft pseudopotentials also need a denser charge-density grid than the
+usual four times the wavefunction cutoff, hence 320 Ry.
+
+Expect absolute gaps roughly 0.15–0.2 eV below the manuscript's for this reason. That is why the
+comparison at the end is built from *differences* between jobs sharing identical settings, where the
+error largely cancels.
+
+### 4.1. K-point sampling and cell size
+
+The k-grid is set per structure, alongside its name:
+
+```python
+MATERIALS = {
+    "MoS2 bilayer 21.8deg d6.5": [6, 6, 1],
+    # "MoS2 bilayer AB1 d6.1": [12, 12, 1],
+    ...
+}
+```
+
+The manuscript does not state its k-sampling. A commensurate supercell has a Brillouin zone smaller
+by its cell count, so it needs fewer divisions than the 1×1 cell for equivalent sampling — hence
+`[6, 6, 1]` for the √7×√7 cell against `[12, 12, 1]` for the 1×1.
+
+Keep the in-plane divisions a multiple of three. K sits at (1/3, 1/3), so a Γ-centred grid whose
+divisions are not divisible by three never samples it, and the K-valley gap is then read at some
+other k-point.
+
+### 4.2. The band structure path belongs to the cell being computed
+
+The path is Γ–M–K–Γ of whichever cell is being calculated. In a supercell the bands are folded onto
+a smaller Brillouin zone, so the point labelled K in the 42-atom plot is not the K point of the
+monolayer. The plots are for reading; the numbers the comparison uses come from the `band_gaps`
+property, which is extracted from the non-self-consistent k-mesh and is unaffected by folding.
+
+
+## 5. Step-by-step instructions
+
+### 5.1. Create the structures
+
+Run the
+[structure creation notebook](interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md).
+Its `INTERFACE_PARAMETERS` list has the three structures compared here active by default —
+building a structure costs seconds, so there is no reason to build fewer. Uncomment further entries
+for the remaining twist angles.
+
+### 5.2. Open the simulation notebook
+
+```
+other/materials_designer/specific_examples/interface_bilayer_twisted_commensurate_lattices_molybdenum_disulfide_SIMULATION.ipynb
+```
+
+### 5.3. Select the materials
+
+Cell 1.2 holds the structures to compute and the k-grid for each:
+
+```python
+MATERIALS = {
+    "MoS2 bilayer 21.8deg d6.5": [6, 6, 1],
+    # "MoS2 bilayer AB1 d6.1": [12, 12, 1],
+    # "MoS2 bilayer AB1 d6.5": [12, 12, 1],
+    ...
+}
+```
+
+One job is created per entry. Uncomment the two AB1 entries to run the full comparison.
+
+### 5.4. Run the notebook
+
+Select *Run* > *Run All*. The notebook will
+[authenticate with the platform]({{ interface_url }}/jupyterlite/authentication.md), load and save
+the materials, build one workflow per material, create and submit one job each, wait for them, and
+then print the results.
+
+The 42-atom job dominates the cost. Raising `PPN` or moving to a larger queue is the sensible lever;
+reducing `INTERFACE_VACUUM` in the structure notebook is the other one, though it should not go
+below the manuscript's ≈ 10 Å of vacuum, and it has to be the same for every job in the comparison.
+
+
+## 6. Expected results
+
+### 6.1. Gaps against twist angle
+
+Each structure produces one row, and the notebook plots the indirect and K-valley direct gaps
+against twist angle — the same axes as Fig. 4b of the manuscript. Alongside each row it shows the
+manuscript's own value, read off that figure: about 1.27 eV for the registered AB stacking, 1.47 eV
+for every twist, 1.60 eV for the eclipsed AA stacking, and a K-valley gap near 1.80 eV throughout.
+
+Absolute gaps come out roughly 0.2 eV below the manuscript's, because the pseudopotentials are not
+its norm-conserving set. Differences between structures computed with identical settings are much
+less affected, and those are what carry the manuscript's claim.
+
+Measured on two structures that differ only in interlayer distance:
+
+| structure | d(Mo–Mo) | indirect | direct (K) |
+|---|---|---|---|
+| `MoS2 bilayer AB1 d6.1` | 6.1 Å | 1.098 eV | 1.612 eV |
+| `MoS2 bilayer AB1 d6.5` | 6.5 Å | 1.297 eV | 1.624 eV |
+
+The indirect gap shifts **+0.199 eV** over that 0.4 Å, against **+0.20 eV** in Fig. 4c, while the
+K-valley gap moves 0.012 eV — the manuscript's result, that the indirect gap tracks the interlayer
+distance and the K-valley gap does not.
+
+### 6.2. Band structure
+
+Each job produces a band structure along Γ–M–K–Γ of its own cell. A supercell's bands are folded
+onto its smaller Brillouin zone, so it carries proportionally more bands over a smaller range — the
+same electronic structure, drawn differently.
+
+## 7. Troubleshooting
+
+The comparison at the same interlayer distance is the one sensitive to k-point sampling, because it
+is the only one between cells of different size. If it disagrees while the others hold, check that
+the supercell's grid is scaled down relative to the 1×1 cell's as described in 4.1.
+
+If every gap is far from 1.5 eV, check the interlayer distance printed for each material against the
+value in its name before looking anywhere else.
+
+
+## 8. Interactive JupyterLite notebook
+
+The notebook below calculates the band structures and evaluates the comparison. Select
+*Run* > *Run All Cells*.
+
+{% with origin_url=config.extra.jupyterlite.origin_url_lab %}
+{% with notebooks_path_root=config.extra.jupyterlite.notebooks_path_root %}
+{% with notebook_name='specific_examples/interface_bilayer_twisted_commensurate_lattices_molybdenum_disulfide_SIMULATION.ipynb' %}
+{% include 'jupyterlite_embed.html' %}
+{% endwith %}
+{% endwith %}
+{% endwith %}
+
+
+## 9. References

--- a/lang/en/docs/tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
+++ b/lang/en/docs/tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
@@ -214,9 +214,11 @@ Select *Run* > *Run All*. The notebook will
 the materials, build one workflow per material, create and submit one job each, wait for them, and
 then print the results.
 
-The 42-atom job dominates the cost. Raising `PPN` or moving to a larger queue is the sensible lever;
-reducing `INTERFACE_VACUUM` in the structure notebook is the other one, though it should not go
-below the manuscript's ≈ 10 Å of vacuum, and it has to be the same for every job in the comparison.
+The 42-atom job dominates the cost. Raising `PPN` or moving to a larger queue is the sensible lever.
+Shrinking the cell is the other one, but there is little room: `TOTAL_CELL_HEIGHT` is already at the
+manuscript's 20 Å, which leaves about 11 Å of vacuum above a bilayer roughly 9 Å thick. Going lower
+departs from the manuscript, and whatever value is used has to be the same for every job in the
+comparison.
 
 
 ## 6. Expected results

--- a/lang/en/docs/tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
+++ b/lang/en/docs/tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
@@ -100,15 +100,12 @@ The simulation notebook computes the first entry by default; uncomment the other
 
 ### 3.1. Interlayer distances are inputs here, not outputs
 
-The distances above are the manuscript's Table S1 LDA values, which are the *relaxed results* of its
-own calculations. This tutorial takes them as given and does not relax the structures.
+The distances above are the manuscript's Table S1 LDA values — the relaxed results of its own
+calculations. This tutorial builds the structures at those distances and does not relax them.
 
-They are also quoted as the averaged **Mo–Mo** separation, while the structure builder takes the gap
-between the facing sulfur planes. The two differ by one monolayer's thickness, about 3.14 Å. The
-structure notebook measures that thickness on the slab it has just built, subtracts it, and prints
-the resulting Mo–Mo separation of the finished structure next to the value it was aiming for — worth
-reading, because passing an interlayer distance through in the wrong convention produces a structure
-that builds, runs and plots perfectly well with the interlayer coupling removed.
+The structure notebook prints the Mo–Mo separation of each finished structure next to the value it
+was aiming for, along with the cell height, so the geometry can be checked against the manuscript at
+a glance.
 
 ### 3.2. Which registry a 0° or 60° stack comes out as
 
@@ -135,21 +132,21 @@ spin-orbit coupling.
 | Functional | LDA (`pz`) | LDA |
 | Pseudopotentials | ultrasoft (GBRV) | norm-conserving |
 | Wavefunction cutoff | 40 Ry, density 320 Ry | 140 Ry |
-| Vacuum | 20 Å region, ≈ 26 Å of vacuum in a ≈ 33 Å cell | 20 Å total cell |
+| Out-of-plane cell | 20 Å | 20 Å |
 | Spin-orbit coupling | off | off |
 | Spin polarization | off | not applicable |
-| Geometry | fixed at Table S1 distances | relaxed |
+| Geometry | interlayer distances from Table S1 | relaxed |
 
 The pseudopotentials are the one real divergence, and it is forced: the platform carries no
 norm-conserving set for Mo or S under LDA, so the closest available match is the ultrasoft GBRV set
-at the same functional. Keeping the functional is what matters here — LDA is what binds this
-bilayer, and PBE without a dispersion correction does not — while the pseudopotential family mostly
-shifts the absolute gaps. Ultrasoft pseudopotentials also need a denser charge-density grid than the
-usual four times the wavefunction cutoff, hence 320 Ry.
+at the same functional. Keeping the functional is what matters — LDA is what binds this bilayer.
 
-Expect absolute gaps roughly 0.15–0.2 eV below the manuscript's for this reason. That is why the
-comparison at the end is built from *differences* between jobs sharing identical settings, where the
-error largely cancels.
+The two cutoffs are not the same quantity. 140 Ry is a norm-conserving *wavefunction* cutoff;
+ultrasoft pseudopotentials converge the wavefunctions far lower and instead need a charge-density
+cutoff eight to twelve times higher, which is the 320 Ry here.
+
+Expect absolute gaps roughly 0.2 eV below the manuscript's as a result. Differences between
+structures computed with identical settings are much less affected, and those carry the result.
 
 ### 4.1. K-point sampling and cell size
 

--- a/lang/en/docs/tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md
+++ b/lang/en/docs/tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md
@@ -43,9 +43,9 @@ First, we navigate to [Materials Designer]({{ interface_url }}/materials-designe
 Then we will use the [JupyterLite]({{ interface_url }}/jupyterlite/overview/) environment to create a twisted bilayer molybdenum disulfide structure.
 
 
-## 3. Create MoS2 bilayer with a twist angle of 22 degrees
+## 3. Create the MoS2 bilayers
 
-### 2.1 Launch JupyterLite Session
+### 3.1. Launch JupyterLite Session
 
 Select the "Advanced > [JupyterLite Transformation]({{ interface_url }}/materials-designer/header-menu/advanced/jupyterlite-dialog/)" menu item to launch the JupyterLite environment.
 
@@ -54,98 +54,115 @@ Select the "Advanced > [JupyterLite Transformation]({{ interface_url }}/material
 
 ### 3.2. Open and modify the notebook
 
-Next, edit `create_twisted_interface_with_commnesurate_lattices.ipynb` notebook to modify the parameters by adding: `TARGET_TWIST_ANGLE = 22` and `INTERFACE_DISTANCE = 6.5` -- found in the publication description.
+Open `specific_examples/interface_bilayer_twisted_commensurate_lattices_molybdenum_disulfide.ipynb`
+— the notebook embedded in section 5 below.
 
-Adjust the "1.1. Set up slab parameters" cell in the notebook according to:
+The first cell lists the configurations to build. Each entry is a name, a twist angle, and an
+interlayer separation; the notebook builds every active entry in one run, so there is no need to
+edit and re-run once per angle:
 
 ```python
-# Material selection and basic parameters
-FILM_INDEX = 0  # Index in the list of materials, to access as materials[FILM_INDEX]
-SUBSTRATE_INDEX = None  # Can be None to use same material as film
+INTERFACE_PARAMETERS = [
+    {"name": "MoS2 bilayer 21.8deg d6.5", "angle": 21.8, "d_mo_mo": 6.5},
+    {"name": "MoS2 bilayer AB1 d6.1", "angle": 60.0, "d_mo_mo": 6.1},
+    {"name": "MoS2 bilayer AB1 d6.5", "angle": 60.0, "d_mo_mo": 6.5},
+    # {"name": "MoS2 bilayer AA3 d6.8", "angle": 0.0, "d_mo_mo": 6.8},
+    # {"name": "MoS2 bilayer 13.2deg d6.5", "angle": 13.2, "d_mo_mo": 6.5},
+    # {"name": "MoS2 bilayer 38.2deg d6.5", "angle": 38.2, "d_mo_mo": 6.5},
+    # {"name": "MoS2 bilayer 46.8deg d6.5", "angle": 46.8, "d_mo_mo": 6.5},
+]
+```
 
-# Twisted interface parameters
-TARGET_TWIST_ANGLE = 22.0  # in degrees
-INTERFACE_DISTANCE = 6.5  # in Angstroms
-INTERFACE_VACUUM = 20.0  # in Angstroms
+!!!note "`d_mo_mo` is the Mo–Mo separation, not a gap"
+    Table S1 of the manuscript tabulates the **averaged Mo–Mo separation** of the two layers, and
+    `d_mo_mo` is that quantity. The notebook subtracts the monolayer thickness itself to get the gap
+    the builder needs. Passing 6.5 Å straight through as a gap would put the layers roughly 3 Å
+    further apart than the manuscript, which is enough to change the indirect gap substantially.
 
-# Commensurate interface parameters (following the test pattern)
-ANGLE_TOLERANCE = 0.5  # in degrees
-MAX_SUPERCELL_MATRIX_INT = 6  # Maximum supercell matrix element value
-RETURN_FIRST_MATCH = True  # If True, returns first solution within tolerance
+The second cell holds the cell and search parameters:
 
+```python
 # Slab creation parameters
 MILLER_INDICES = (0, 0, 1)  # Miller indices for slab creation
 NUMBER_OF_LAYERS = 1  # Number of layers in the slab
-USE_CONVENTIONAL_CELL = True
-USE_ORTHOGONAL_C = True
 
-STACKING_DIRECTION = "z" # Stacking direction for the slab, can be "x", "y", or "z"
+TOTAL_CELL_HEIGHT = 20.0  # out-of-plane cell dimension in Angstroms, as in the article
+
+# Search algorithm parameters
+MAX_REPETITION = None  # Maximum supercell matrix element value (None for automatic)
+ANGLE_TOLERANCE = 0.5  # in degrees
+RETURN_FIRST_MATCH = True  # If True, returns first solution within tolerance
 
 # Visualization parameters
 SHOW_INTERMEDIATE_STEPS = True
 VISUALIZE_REPETITIONS = [3, 3, 1]
 ```
 
+`TOTAL_CELL_HEIGHT` is the **total** out-of-plane cell dimension, matching the 20 Å the manuscript
+used to separate the bilayer from its periodic images. The notebook derives the vacuum from it, so
+the built cell comes out at 20 Å regardless of which interlayer separation is requested.
+
 ![Notebook setup](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/jl-set-nb.png "Notebook setup")
 
 
 ### 3.3. Run the Notebook
 
-After setting the parameters, run the notebook to create the twisted bilayer molybdenum disulfide structure.
+After setting the parameters, run the notebook to build every active configuration.
 
 ![Run All](../../../images/jupyterlite/run-all.webp "Run All")
 
-### 3.4. View Results and pass to Materials Designer
+### 3.4. Check the geometry
 
-The generation might take some time.
-After that, the user can pass the material to the Materials Designer for further analysis.
+For each structure the notebook prints the atom count, the achieved Mo–Mo separation next to the
+value that was asked for, the cell height, and — for the registered stacks at 0° and 60° — which
+stacking registry the search actually produced:
 
-The interface for 22 degrees twist is shown below.
-
-![Result Material, 22 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-22.png "MoS2 Twisted Bilayer, 22 degrees")
-
-## 4. Create bilayers with other twist angles
-
-### 4.1. Repeat the steps above
-To create a twisted bilayer MoS2 structure with a different twist angle, repeat the steps above, adjusting the `TARGET_TWIST_ANGLE` and `INTERFACE_DISTANCE` parameters accordingly.
-
-Values for angle and associated interlayer separation provided below come from the description of Figure 4 in the publication, below each example has an image of the resulting material.
-
-```python
-TARGET_TWIST_ANGLE = 0.0
-INTERFACE_DISTANCE = 6.8
 ```
+MoS2 bilayer 21.8deg d6.5: 21.8°, 42 atoms, d(Mo-Mo) 6.500 Å (target 6.5 Å), cell c 20.00 Å
+MoS2 bilayer AB1 d6.1: 60.0°, 6 atoms, d(Mo-Mo) 6.100 Å (target 6.1 Å), cell c 20.00 Å, AA1/AB1 (S over Mo)
+```
+
+The registry matters because Table S1 gives a different interlayer distance to each one: 6.1–6.2 Å
+for the AA1/AB1 and AA2/AB2 stacks, 6.8 Å for AA3/AB3 where sulfur sits directly over sulfur.
+
+### 3.5. View results and pass to Materials Designer
+
+The generation might take some time. Each finished structure is saved to the `uploads` folder under
+its `name`, and can also be passed to the Materials Designer for further analysis.
+
+The interface for the 21.8° twist is shown below.
+
+![Result Material, 22 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-22.png "MoS2 Twisted Bilayer, 21.8 degrees")
+
+## 4. The other twist angles
+
+The remaining configurations are already in `INTERFACE_PARAMETERS`, commented out. Uncomment the
+ones needed and re-run; the separations come from Table S1 of the manuscript.
+
+| Entry | Angle | `d_mo_mo` | Atoms |
+|---|---|---|---|
+| `MoS2 bilayer AA3 d6.8` | 0° | 6.8 Å | 6 |
+| `MoS2 bilayer 13.2deg d6.5` | 13.2° | 6.5 Å | 114 |
+| `MoS2 bilayer 21.8deg d6.5` | 21.8° | 6.5 Å | 42 |
+| `MoS2 bilayer 38.2deg d6.5` | 38.2° | 6.5 Å | 42 |
+| `MoS2 bilayer 46.8deg d6.5` | 46.8° | 6.5 Å | 114 |
+| `MoS2 bilayer AB1 d6.1` | 60° | 6.1 Å | 6 |
+
+The 13.2° and 46.8° cells hold 114 atoms and take noticeably longer to build than the rest.
 
 ![Result Material, 0 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-0.png "MoS2 Twisted Bilayer, 0 degrees")
 
+![Result Material, 13 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-13.png "MoS2 Twisted Bilayer, 13.2 degrees")
 
-```python
-TARGET_TWIST_ANGLE =  13.0
-INTERFACE_DISTANCE =  6.5
-```
+![Result Material, 38 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-38.png "MoS2 Twisted Bilayer, 38.2 degrees")
 
-![Result Material, 13 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-13.png "MoS2 Twisted Bilayer, 13 degrees")
-
-```python
-TARGET_TWIST_ANGLE = 38.0
-INTERFACE_DISTANCE = 6.5
-```
-
-![Result Material, 38 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-38.png "MoS2 Twisted Bilayer, 38 degrees")
-
-```python
-TARGET_TWIST_ANGLE = 47.0
-INTERFACE_DISTANCE = 6.5
-```
-
-![Result Material, 47 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-47.png "MoS2 Twisted Bilayer, 47 degrees")
-
-```python
-TARGET_TWIST_ANGLE = 60.0
-INTERFACE_DISTANCE = 6.2
-```
+![Result Material, 47 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-47.png "MoS2 Twisted Bilayer, 46.8 degrees")
 
 ![Result Material, 60 degrees](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/mos2-result-wavejs-60.png "MoS2 Twisted Bilayer, 60 degrees")
+
+Once the structures exist, the
+[band structure tutorial](interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md)
+loads them by name and reproduces the manuscript's band gaps.
 
 
 ## 5. Interactive JupyterLite Notebook

--- a/lang/en/docs/tutorials/materials/specific/overview.md
+++ b/lang/en/docs/tutorials/materials/specific/overview.md
@@ -97,7 +97,7 @@ This document provides a comprehensive catalog of materials science tutorials or
 ##### 2.1.4.1. Twisted Bilayer MoS2 Commensurate Lattices <span class="btn badge b-info border-50">C-2D-INT-C</span>
 
 **Structure**: [Create Twisted MoS2 Commensurate Lattices](interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md)  
-**Properties**: Calculate band gaps and band structure (Coming Soon)  
+**Properties**: [Calculate Band Structure of Twisted MoS2 Bilayers](interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md)  
 **DOI**: [10.1038/ncomms5966](https://doi.org/10.1038/ncomms5966){:target='_blank'} [@Liu2014; @Zhang2016; @Cao2018]
 
 ![Twisted Bilayer Molybdenum Disulfide](../../../images/tutorials/materials/interfaces/twisted-bilayer-molybdenum-disulfide/MoS2-twisted-bilayers.png "Twisted Bilayer Molybdenum Disulfide"){ style="max-height:500px;width:auto;" }

--- a/mkdocs-guide.yml
+++ b/mkdocs-guide.yml
@@ -194,7 +194,6 @@ nav:
             - Overview:                                                         tutorials/materials/specific/overview.md
             - Substitutional Defects in Graphene:                               tutorials/materials/specific/defect-point-substitution-graphene.md
             - Substitutional Defects in Graphene (Band Structure):              tutorials/materials/specific/defect-point-substitution-graphene-simulation.md
-            - Twisted Bilayer MoS2 Band Structure:                          tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
             - Vacancy-Substitution Pair in GaN:                                 tutorials/materials/specific/defect-point-pair-gallium-nitride.md
             - Vacancy Defect in h-BN:                                           tutorials/materials/specific/defect-point-vacancy-boron-nitride.md
             - Interstitial Defect in SnO:                                       tutorials/materials/specific/defect-point-interstitial-tin-oxide.md
@@ -202,6 +201,7 @@ nav:
             - Step Surface Defect on Pt(111):                                   tutorials/materials/specific/defect-surface-step-platinum.md
             - Twisted Bilayer h-BN Nanoribbons:                                 tutorials/materials/specific/interface-bilayer-twisted-nanoribbons-boron-nitride.md
             - Twisted Bilayer MoS2:                                             tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md
+            - Twisted Bilayer MoS2 (Band Structure):                            tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
             - Adatom Surface Defects on Graphene:                               tutorials/materials/specific/defect-surface-adatom-graphene.md
             - H-Passivated Silicon Nanowire:                                    tutorials/materials/specific/passivation-edge-nanowire-silicon.md
             - H-Passivated Silicon (100) Surface:                               tutorials/materials/specific/passivation-surface-silicon.md

--- a/mkdocs-guide.yml
+++ b/mkdocs-guide.yml
@@ -194,6 +194,7 @@ nav:
             - Overview:                                                         tutorials/materials/specific/overview.md
             - Substitutional Defects in Graphene:                               tutorials/materials/specific/defect-point-substitution-graphene.md
             - Substitutional Defects in Graphene (Band Structure):              tutorials/materials/specific/defect-point-substitution-graphene-simulation.md
+            - Twisted Bilayer MoS2 Band Structure:                          tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
             - Vacancy-Substitution Pair in GaN:                                 tutorials/materials/specific/defect-point-pair-gallium-nitride.md
             - Vacancy Defect in h-BN:                                           tutorials/materials/specific/defect-point-vacancy-boron-nitride.md
             - Interstitial Defect in SnO:                                       tutorials/materials/specific/defect-point-interstitial-tin-oxide.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,7 +161,7 @@ nav:
             - Step Surface Defect on Pt(111):                               tutorials/materials/specific/defect-surface-step-platinum.md
             - Twisted Bilayer h-BN nanoribbons:                             tutorials/materials/specific/interface-bilayer-twisted-nanoribbons-boron-nitride.md
             - Twisted Bilayer MoS2 commensurate lattices:                   tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md
-            - Twisted Bilayer MoS2 Band Structure:                          tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
+            - Twisted Bilayer MoS2 commensurate lattices (Band Structure):  tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
             - Adatom Surface Defects on Graphene:                           tutorials/materials/specific/defect-surface-adatom-graphene.md
             - H-Passivated Silicon Nanowire:                                tutorials/materials/specific/passivation-edge-nanowire-silicon.md
             - H-Passivated Silicon (100) Surface:                           tutorials/materials/specific/passivation-surface-silicon.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
             - Step Surface Defect on Pt(111):                               tutorials/materials/specific/defect-surface-step-platinum.md
             - Twisted Bilayer h-BN nanoribbons:                             tutorials/materials/specific/interface-bilayer-twisted-nanoribbons-boron-nitride.md
             - Twisted Bilayer MoS2 commensurate lattices:                   tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide.md
+            - Twisted Bilayer MoS2 Band Structure:                          tutorials/materials/specific/interface-bilayer-twisted-commensurate-lattices-molybdenum-disulfide-simulation.md
             - Adatom Surface Defects on Graphene:                           tutorials/materials/specific/defect-surface-adatom-graphene.md
             - H-Passivated Silicon Nanowire:                                tutorials/materials/specific/passivation-edge-nanowire-silicon.md
             - H-Passivated Silicon (100) Surface:                           tutorials/materials/specific/passivation-surface-silicon.md


### PR DESCRIPTION
## SOF-8014 — tutorial: band structure of twisted MoS2 bilayers

Companion to **mat3ra/api-examples#358**, which adds the notebooks this page describes.

Reproduces the electronic-structure result of **Liu et al., *Evolution of interlayer coupling in
twisted molybdenum disulfide bilayers*, Nat. Commun. 5, 4966 (2014)** —
[10.1038/ncomms5966](https://doi.org/10.1038/ncomms5966): the indirect gap of a MoS2 bilayer is set
by the interlayer distance, while the K-valley direct gap barely moves.

### Contents

- the manuscript's result, and that Kohn-Sham gaps are not the photoluminescence peaks it also
  reports
- the prerequisite structure-creation tutorial, which builds and names the materials
- the structures computed, and that the interlayer distances are inputs taken from Table S1 rather
  than relaxed here
- which stacking registry a 0° or 60° build produces, since the builder has no registry parameter
- computational settings and where they differ from the manuscript's
- results: gaps against twist angle, on the manuscript's own axes

### Where it differs from the manuscript

The manuscript used LDA with norm-conserving pseudopotentials. The platform carries none for Mo or S
under LDA, so the tutorial uses the ultrasoft GBRV set at the same functional — keeping LDA matters,
since it is what binds this bilayer. Absolute gaps land ~0.2 eV low as a result; differences between
structures computed with identical settings are much less affected, and the page says so.

### Verified

- measured on two structures differing only in interlayer distance: indirect gaps 1.098 eV at 6.1 Å
  and 1.297 eV at 6.5 Å, a **+0.199 eV** shift against the manuscript's **+0.20 eV**, with the
  K-valley gap moving 0.012 eV
- every relative link, the image, the `jupyterlite_embed` target and the `@Liu2014` citation resolve
- registered in both `mkdocs.yml` and `mkdocs-guide.yml`, matching the sibling simulation tutorial;
  both parse

Not rendered locally — mkdocs is not installed in this worktree, so the build is unverified beyond
the checks above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
